### PR TITLE
Status Message are not showing as dismissed despite cookie being set. 

### DIFF
--- a/includes/admin/class-bc-status-warning.php
+++ b/includes/admin/class-bc-status-warning.php
@@ -35,8 +35,9 @@ class BC_Status_Warning {
 	public function __construct() {
 
 		$failed_services = $this->_check_for_failed();
+		$status_dismissed = filter_var( $_COOKIE['bc-status-dismissed'], FILTER_VALIDATE_BOOLEAN );
 
-		if ( is_array( $failed_services ) && ! empty( $failed_services ) && ( ! isset( $_COOKIE['bc-status-dismissed'] ) || true !== $_COOKIE['bc-status-dismissed'] ) ) {
+		if ( is_array( $failed_services ) && ! empty( $failed_services ) && false === $status_dismissed ) {
 
 			add_action( 'admin_notices', array( $this, 'action_admin_notices' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'action_admin_enqueue_scripts' ) );


### PR DESCRIPTION
Status message will correct be hidden after they are dismissed.

Cookies are read as strings by default and this was explicitly checked against a boolean. Using the filter_var allows a safe method of checking the cookie and defaulting to false if it doesn't exist, is empty, or equals any value but '1', 'true', 'on' and 'yes'.
