### PR TITLE
Filter the shortcode player HTML

### DIFF
--- a/includes/class-bc-utility.php
+++ b/includes/class-bc-utility.php
@@ -850,7 +850,20 @@ class BC_Utility {
 
 		$html .= '<!-- End of Brightcove Player -->';
 
-		return apply_filters( 'brightcove_video_html', $html, $type, $id, $account_id, $player_id, $width, $height );
+		/**
+		 * Filter the Brightcove Player HTML.
+		 *
+		 * @param string  $html       HTML markup of the Brightcove Player.
+		 * @param string  $type       "playlist" or "video".
+		 * @param string  $id         The brightcove player or video ID.
+		 * @param string  $account_id The Brightcove account ID.
+		 * @param string  $player_id  The brightcove player ID.
+		 * @param int     $width      The Width to display.
+		 * @param int     $height     The height to display.
+		 */
+		$html = apply_filters( 'brightcove_video_html', $html, $type, $id, $account_id, $player_id, $width, $height );
+
+		return $html;
 
 	}
 


### PR DESCRIPTION
Added a filter to the video shortcode HTML output. This allows for the ability to change the player and use the Brightcove legacy smart player along with the same parameters. 
