### PR TITLE
Fallback to default player for playlist rendering

### DIFF
--- a/assets/js/src/tinymce.js
+++ b/assets/js/src/tinymce.js
@@ -63,7 +63,7 @@
 					playlistWidth = 500;
 				}
 
-				var player_id = bctiny.playlistEnabledPlayers[self.shortcode.attrs.named.account_id][0];
+				var player_id = bctiny.playlistEnabledPlayers[self.shortcode.attrs.named.account_id][0] || 'default';
 				self.content  = '<iframe style="width: ' + playlistWidth + 'px; height: ' + playlistHeight + 'px;" src="//players.brightcove.net/' + utilities.bc_sanitize_ids( self.shortcode.attrs.named.account_id ) + '/' + player_id + '_default/index.html?playlistId=' + utilities.bc_sanitize_ids( self.shortcode.attrs.named.playlist_id ) + '" width="645" height="352" allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe>';
 				// add allowfullscreen attribute to main iframe to allow video preview in full screen
 				if ( typeof document.getElementById( 'content_ifr' ) !== 'undefined' ) {
@@ -119,7 +119,7 @@
 						playlistWidth = 500;
 					}
 
-					var player_id = bctiny.playlistEnabledPlayers[options.shortcode.attrs.named.account_id][0];
+					var player_id = bctiny.playlistEnabledPlayers[options.shortcode.attrs.named.account_id][0] || 'default';
 					this.content  = '<iframe style="width: ' + playlistWidth + 'px; height: ' + playlistHeight + 'px;" src="//players.brightcove.net/' + utilities.bc_sanitize_ids( options.shortcode.attrs.named.account_id ) + '/' + player_id + '_default/index.html?playlistId=' + utilities.bc_sanitize_ids( options.shortcode.attrs.named.playlist_id ) + '" width="645" height="352" allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe>';
 					this.content = 'no';
 					// add allowfullscreen attribute to main iframe to allow video preview in full screen


### PR DESCRIPTION
Found a lot of issues where bctiny.playlistEnabledPlayers[options.shortcode.attrs.named.account_id] is false rather than an array of player IDs. wp cache flush cleans this up, however I wasn't able to find the root cause of the issue.

This fix falls back to the default player if we can't find one to avoid not rendering the playlist in tinymce.