### PR TITLE
Add strict parameter to in_array

### DIFF
--- a/includes/api/class-bc-text-track.php
+++ b/includes/api/class-bc-text-track.php
@@ -42,7 +42,7 @@ class BC_Text_Track {
 	public function __construct( $url, $language = 'en-US', $kind = 'captions', $label = '', $default = false ) {
 		$this->url = esc_url_raw( $url );
 		$this->srcLang = sanitize_text_field( $language );
-		if ( ! in_array( $kind, array( 'captions', 'subtitles', 'descriptions', 'chapters', 'metadata' ) ) ) {
+		if ( ! in_array( $kind, array( 'captions', 'subtitles', 'descriptions', 'chapters', 'metadata' ), true ) ) {
 			$this->kind = 'captions';
 		} else {
 			$this->kind = $kind;


### PR DESCRIPTION
Have tested text track uploads since adding the param, all seems to be normal.

Resolves feedback we got on 1.2.1 from VIP.