### PR TITLE
Add support for all account players when embeding videos

### DIFF
--- a/includes/admin/class-bc-templates.php
+++ b/includes/admin/class-bc-templates.php
@@ -543,7 +543,7 @@ class BC_Admin_Templates {
 						if ( 'edit' === $parent_base ) { ?>
 							<div class="video-player">
 								<span class="title"><?php esc_html_e( 'Video Player: ', 'brightcove' ); ?></span>
-								<# _.each( wpbc.players.items, function ( player ) { #>
+                                <# _.each( wpbc.players[data.account_id].items, function ( player ) { #>
 									<label class="brightcove-player" for="player-{{ player.id }}">
 										<input id="player-{{ player.id }}" type="radio" name="video-player-field" value="{{ player.id }}" <# if ( 'default' === player.id ) { #>checked <# } #>>
 										{{ player.name }}

--- a/includes/api/class-bc-player-management-api.php
+++ b/includes/api/class-bc-player-management-api.php
@@ -133,6 +133,31 @@ class BC_Player_Management_API extends BC_API {
 
 	}
 
+    /**
+     * List all players for all accounts available
+     *
+     * Returns a list of available players for each accounts, as well as
+     * the total count of players available, grouped by account
+     *
+     * @since 1.2.3
+     *
+     * @return array|bool Array of available players or false if error
+     */
+    public function all_player_by_account() {
+
+        global $bc_accounts;
+
+        $all_accounts_id = $bc_accounts->get_all_accounts_id();
+        $players = false;
+
+        foreach ($all_accounts_id as $account_id) {
+            $url = esc_url_raw( self::BASE_URL . $account_id . '/players/');
+            $players[$account_id] = $this->send_request($url);
+        }
+
+        return $players;
+    }
+
 	/**
 	 * Update a player
 	 *

--- a/includes/class-bc-accounts.php
+++ b/includes/class-bc-accounts.php
@@ -36,6 +36,16 @@ class BC_Accounts {
 		$this->current_account  = $this->original_account;
 	}
 
+    public function get_all_accounts_id() {
+        $all_accounts = $this->get_all_accounts();
+        $account_ids = array();
+
+        foreach ($all_accounts as $account) {
+            $account_ids[] = $account["account_id"];
+        }
+        return $account_ids;
+    }
+
 	public function get_account_id() {
 
 		return $this->current_account ? $this->current_account['account_id'] : false;
@@ -409,7 +419,7 @@ class BC_Accounts {
 
 				/**
 				 * Fired after an account is deleted from the WordPress admin
-				 * 
+				 *
 				 * @param string $hash Account hash according to Brightcove
 				 */
 				do_action( 'brightcove_deleted_account', $hash );

--- a/includes/class-bc-setup.php
+++ b/includes/class-bc-setup.php
@@ -198,7 +198,7 @@ class BC_Setup {
 		$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
 		$player_api = new BC_Player_Management_API();
-		$players    = $player_api->player_list();
+        $players    = $player_api->all_player_by_account();
 
 		$js_variable = array(
 			'path'           => esc_url( BRIGHTCOVE_URL . 'assets/js/src/' ),


### PR DESCRIPTION
When changing from one account to the other when embeding a video to a post, the video players don't change. The video players used for one account will not work on other accounts. So, I made a change to account for all account players.

Please let me know if you see anything wrong in that or if you see a way to do it more efficiently.

Thank you.