### PR TITLE
Limit BC Status Checks

### DIFF
--- a/brightcove-video-connect.php
+++ b/brightcove-video-connect.php
@@ -102,8 +102,8 @@ if ( ! defined( 'WPCOM_IS_VIP_ENV' ) || ! WPCOM_IS_VIP_ENV ) {
 require_once( BRIGHTCOVE_PATH . 'includes/class-bc-setup.php' );
 require_once( BRIGHTCOVE_PATH . 'includes/class-bc-notification-api.php' );
 
-// Check Brightcove status if is_admin().
-if ( is_admin() ) {
+// Check Brightcove status if is_admin() and not an ajax request
+if ( is_admin() && ! ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
 
 	require_once( BRIGHTCOVE_PATH . 'includes/admin/class-bc-status-warning.php' );
 	new BC_Status_Warning();

--- a/includes/admin/class-bc-status-warning.php
+++ b/includes/admin/class-bc-status-warning.php
@@ -57,13 +57,6 @@ class BC_Status_Warning {
 	 */
 	protected function _check_for_failed() {
 
-		if ( function_exists( 'vip_safe_wp_remote_get' ) ) {
-			$status_response = vip_safe_wp_remote_get( $this->status_endpoint );
-		} else {
-			$status_response = wp_remote_get( $this->status_endpoint );
-		}
-		$statuses        = array();
-
 		if ( ! defined( 'WPCOM_IS_VIP_ENV' ) || ! WPCOM_IS_VIP_ENV ) {
 			$failed_services = get_site_transient( 'brightcove_failed_services' );
 		} else {
@@ -73,6 +66,13 @@ class BC_Status_Warning {
 
 		if ( false === $failed_services ) {
 
+			if ( function_exists( 'vip_safe_wp_remote_get' ) ) {
+				$status_response = vip_safe_wp_remote_get( $this->status_endpoint );
+			} else {
+				$status_response = wp_remote_get( $this->status_endpoint );
+			}
+			$statuses        = array();
+			
 			$failed_services = array();
 			$timeout         = 300; // Used for transient. 5 min if a problem, 60 if all is well.
 


### PR DESCRIPTION
Towards #53 
Skips BC status checks on ajax requests, and checks for/stores in cache the results of the remote request.