### PR TITLE
Label Change from Add Source to Add Brightcove Account

### DIFF
--- a/includes/admin/class-bc-admin-settings-page.php
+++ b/includes/admin/class-bc-admin-settings-page.php
@@ -63,7 +63,7 @@ class BC_Admin_Settings_Page {
 			</table>
 
 			<p>
-				<a href="<?php echo esc_url( admin_url( 'admin.php?page=page-brightcove-edit-source' ) ); ?>" class="button action"><?php esc_html_e( 'Add Source', 'brightcove' ); ?></a>
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=page-brightcove-edit-source' ) ); ?>" class="button action"><?php esc_html_e( 'Add Brightcove Account', 'brightcove' ); ?></a>
 			</p>
 
 		</div>

--- a/includes/admin/class-bc-admin-sources.php
+++ b/includes/admin/class-bc-admin-sources.php
@@ -217,7 +217,7 @@ class BC_Admin_Sources {
 		<div class="wrap">
 			<h2><?php
 				printf( '<img src="%s" class="bc-page-icon"/>', plugins_url( 'images/menu-icon.svg', dirname( __DIR__ ) ) );
-				?><?php esc_html_e( 'Add Source', 'brightcove' ) ?></h2>
+				?><?php esc_html_e( 'Add Brightcove Account', 'brightcove' ) ?></h2>
 
 			<form action="" method="post">
 				<table class="form-table brightcove-add-source-name">


### PR DESCRIPTION
Changed Button text to ready 'Add Brightcove Account'. Change title on next screen to match new button name