### PR TITLE
filter for all players based on account

### DIFF
--- a/includes/api/class-bc-player-management-api.php
+++ b/includes/api/class-bc-player-management-api.php
@@ -155,7 +155,7 @@ class BC_Player_Management_API extends BC_API {
             $players[$account_id] = $this->send_request($url);
         }
 
-        return $players;
+        return apply_filters( 'brightcove_all_player_by_account', $players );
     }
 
 	/**


### PR DESCRIPTION
Looks like this new function got added with my last PR in hopes to modify the list of players in the media modal. https://github.com/10up/brightcove-video-connect/pull/63

https://github.com/10up/brightcove-video-connect/commit/47e60cb677a18e2149039cb6e9d89590a6a8f60f

Adding a filter here on the new function.