### PR TITLE
Parse default args

### DIFF
--- a/includes/class-bc-setup.php
+++ b/includes/class-bc-setup.php
@@ -250,7 +250,11 @@ class BC_Setup {
 		wp_localize_script( 'brightcove-admin', 'wpbc', $js_variable );
 		wp_enqueue_script( 'brightcove-admin' );
 
-		wp_enqueue_media( array( 'post' => $GLOBALS['post_ID'] ) );
+		if ( isset( $GLOBALS['post_ID'] ) ) {
+			wp_enqueue_media( array( 'post' => $GLOBALS['post_ID'] ) );
+		} else {
+			wp_enqueue_media();
+		}
 
 		wp_register_style( 'brightcove-video-connect', esc_url( BRIGHTCOVE_URL . 'assets/css/brightcove_video_connect' . $suffix . '.css' ), array() );
 		wp_enqueue_style( 'brightcove-video-connect' );

--- a/includes/class-bc-setup.php
+++ b/includes/class-bc-setup.php
@@ -250,7 +250,7 @@ class BC_Setup {
 		wp_localize_script( 'brightcove-admin', 'wpbc', $js_variable );
 		wp_enqueue_script( 'brightcove-admin' );
 
-		wp_enqueue_media();
+		wp_enqueue_media( array( 'post' => $GLOBALS['post_ID'] ) );
 
 		wp_register_style( 'brightcove-video-connect', esc_url( BRIGHTCOVE_URL . 'assets/css/brightcove_video_connect' . $suffix . '.css' ), array() );
 		wp_enqueue_style( 'brightcove-video-connect' );


### PR DESCRIPTION
Currently oEmbeds in the editor were broken for new plain text links due to a bug in `wp_enqueue_media`.

We need to make sure we pass in the default args to fix this.

Before:
![before](https://cloud.githubusercontent.com/assets/1377956/20334582/f5d733fa-ac06-11e6-94cd-c78d636192f9.png)

After:
![after](https://cloud.githubusercontent.com/assets/1377956/20334585/fd332b04-ac06-11e6-8f7e-e3d3024f7f08.png)

Props to @rmccue for debugging it with me!