### PR TITLE
Check if option exists before attempting to delete it

### DIFF
--- a/includes/class-bc-setup.php
+++ b/includes/class-bc-setup.php
@@ -302,7 +302,9 @@ class BC_Setup {
 
 		if ( count( $bc_accounts->get_sanitized_all_accounts() ) > 0 ) {
 
-			delete_option( '_brightcove_plugin_activated' );
+			if ( false !== get_option( '_brightcove_plugin_activated' ) ) {
+				delete_option( '_brightcove_plugin_activated' );
+			}
 
 			return;
 


### PR DESCRIPTION
Since the delete_option performs always at least one SQL query in order to figure out whether the option exists, we can save one database query by checking whether the option even exists before attempting
 to delete it.

In case of the WordPress.com platform, such a check can even prevent alloptions cache flush which happens when the `delete_option` is called.

See https://developer.wordpress.org/reference/functions/delete_option/ for more details.

We have already deployed this patch to production on the WordPress.com platform, since it has been causing issues for certain sites hosted in there.

Let me know if you have any questions.