### PR TITLE
Increase timeout

### DIFF
--- a/includes/api/class-bc-api.php
+++ b/includes/api/class-bc-api.php
@@ -103,7 +103,7 @@ abstract class BC_API {
 		$request               = BC_Utility::get_cache_item( $transient_key );
 		if ( false === $request ) {
 			if ( function_exists( 'vip_safe_wp_remote_get' ) ) {
-				$request = vip_safe_wp_remote_get( $url, '', 3, 1, 20, $args );
+				$request = vip_safe_wp_remote_get( $url, '', 3, 3, 20, $args );
 			} else {
 				$request = wp_remote_get( $url, $args );
 			}


### PR DESCRIPTION
VIP Go helper function includes a default 1s timeout. In the plugin, a timeout from Wordpress produces an empty response, which can manifest as a blank Videos grid.

Increasing timeout from 1s to 3s for vip_safe_wp_remote_get allows for more time for the API response, resolving the above issue in testing.