### PR TITLE
search in line with brightcove studio search

### DIFF
--- a/includes/api/class-bc-api.php
+++ b/includes/api/class-bc-api.php
@@ -149,8 +149,6 @@ abstract class BC_API {
 			return false;
 		}
 
-		$url = esc_url_raw( $url );
-
 		$transient_key = false;
 		if ( $method === "GET" ) {
 			$hash           = substr( BC_Utility::get_hash_for_object( array(

--- a/includes/api/class-bc-cms-api.php
+++ b/includes/api/class-bc-cms-api.php
@@ -426,6 +426,9 @@ class BC_CMS_API extends BC_API {
 			$args['q'] = sanitize_text_field( $query );
 
 		}
+		// rawurlencode will convert spaces to %20, and plus signs to %2b, which is required according to BC API Docs.
+
+		$args = array_map( 'rawurlencode', $args );
 
 		$url  = add_query_arg(
 			$args,


### PR DESCRIPTION
Search function was not producing the same results as in Brightcove Studio. With two word searches, the same results would come whether it was formatted `word word`, `word+word`, or `"word word"`. This fix addresses that.