### PR TITLE
Fix: Check for valid API response before accessing it

### DIFF
--- a/includes/api/class-bc-cms-api.php
+++ b/includes/api/class-bc-cms-api.php
@@ -716,11 +716,13 @@ class BC_CMS_API extends BC_API {
 			$request = $this->send_request( esc_url_raw( self::CMS_BASE_URL . $this->get_account_id() . '/folders' ) );
 			$folders = array();
 
-			foreach ( $request as $folder ) {
-				$folders[ $folder['id'] ] = $folder['name'];
-			}
+			if ( $request && ! is_wp_error( $request ) ) {
+				foreach ( $request as $folder ) {
+					$folders[ $folder['id'] ] = $folder['name'];
+				}
 
-			set_transient( $cache_key, $folders, 600 );
+				set_transient( $cache_key, $folders, 600 );
+			}
 		}
 
 		return $folders;


### PR DESCRIPTION
**Issue:** PHP notices thrown on post list and post edit screens when no BC account information available.

**To reproduce:**

* Install the latest stable WordPress version.
* Make sure `WP_DEBUG` is `true`.
* Activate the latest stable version of this plugin.
* Navigate to Posts > All posts.
* Observe PHP Notices being displayed.
* Navigate to New post screen.
* Observe PHP Notices being displayed.

**Fix:**

* In the `fetch_folders` method, make sure `$request` resolves to non-error value (not `false`, not `WP_Error` instance).