### PR TITLE
Fix video_list from returning both playable and unplayable videos

### DIFF
--- a/includes/api/class-bc-cms-api.php
+++ b/includes/api/class-bc-cms-api.php
@@ -442,8 +442,10 @@ class BC_CMS_API extends BC_API {
 			$args['sort'] = sanitize_text_field( $sort );
 		}
 
+		$args['playable'] = 'true';
+
 		if ( false === $playable ) {
-			$args['playable'] = false;
+			$args['playable'] = 'false';
 		}
 
 		if ( '' != sanitize_text_field( $query ) ) {


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

The Brightcove CMS API appears to require the playable variable set to true or false, otherwise it will fetch all videos of either state if left out, which is what is happening now.

https://support.brightcove.com/overview-cms-api#search

In addition to this, the previous code was setting a boolean, essentially remove it from the query string all together, so it would never actually pass the required `false` string:

```
		if ( false === $playable ) {
			$args['playable'] = false;
		}
```

This fix ensures `%2Bplayable:true` or `%2Bplayable:false` is properly passed via depend on what the user passes to the method.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

Fixes a bug.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

I'm piggy backing on `BC_CMS_API::video_list` for a CLI script, and I noticed it's pulling in scheduled videos.

With this fix, the URL sent is now `https://cms.api.brightcove.com/v1/accounts/XXXXXX/videos?limit=100&sort=-created_at&playable=true&q=playable%3Atrue`or `https://cms.api.brightcove.com/v1/accounts/XXXXXX/videos?limit=100&sort=-created_at&playable=true&q=playable%3Afalse`

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->

- Ensure  `BC_CMS_API::video_list` properly fetches playable and unplayable videos.
