### PR TITLE
Prevent a fatal error when API request fails

### DIFF
--- a/includes/api/class-bc-player-management-api2.php
+++ b/includes/api/class-bc-player-management-api2.php
@@ -67,13 +67,14 @@ class BC_Player_Management_API2 extends BC_API {
 
 			$url             = esc_url_raw( self::BASE_URL . $account_id . '/players/' );
 			$account_players = $this->send_request( $url );
+
+			if ( ! $account_players || is_wp_error( $account_players ) ) {
+				return [];
+			}
+
 			usort( $account_players['items'], 'BC_Utility::compare_player_update_date' );
 
 			$players[ $account_id ] = array();
-
-			if ( is_wp_error( $account_players ) ) {
-				return [];
-			}
 
 			foreach ( $account_players['items'] as $key => $player ) {
 				// If a player is set to inactive, we should not send any data about it to the plugin


### PR DESCRIPTION
### Description of the Change

We had an issue where API credentials were revoked and it caused a fatal error on our site. This error originated in the code that gets a list of all available players. The request to get the players will fail and we have a `is_wp_error` check on that but we don't check for that until after we try and use the returned value (which causes fatals if that value is an error).

This PR moves that check up prior to us trying to use that value and also adds a check to ensure the returned value isn't `false`.

### Alternate Designs

None

### Benefits

Prevent fatal errors if API credentials are revoked.

### Possible Drawbacks

None

### Verification Process

This fix was pushed into our staging environment that was experiencing the fatal errors and this resolved those

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.