### PR TITLE
Escape HTML attribute by esc_attr()

### DIFF
--- a/includes/admin/class-bc-admin-labels-page.php
+++ b/includes/admin/class-bc-admin-labels-page.php
@@ -40,7 +40,7 @@ class BC_Admin_Labels_Page {
 						<tr class="form-field form-required term-name-wrap">
 							<th scope="row"><label for="name">Label</label></th>
 							<td>
-								<input name="label-update" id="name" type="text" value="<?php echo esc_html( end ( array_filter( explode( '/', $_GET['update_label'] ) ) ) ); ?>" size="40" aria-required="true">
+								<input name="label-update" id="name" type="text" value="<?php echo esc_attr( end ( array_filter( explode( '/', $_GET['update_label'] ) ) ) ); ?>" size="40" aria-required="true">
 								<p class="description"><?php esc_html_e( 'Enter the new label name.', 'brightcove' ); ?></p>
 							</td>
 						</tr>


### PR DESCRIPTION
Replaces HTML attribute escaping function with `esc_attr()` in stead of `esc_html()`
