### PR TITLE
Minor refactor to definition of $data array

### DIFF
--- a/includes/api/class-bc-cms-api.php
+++ b/includes/api/class-bc-cms-api.php
@@ -815,11 +815,12 @@ class BC_CMS_API extends BC_API {
 	 * @return mixed The request response.
 	 */
 	public function add_label( $name, $path ) {
-		$data['path'] = '';
+		
+		$data = array( 'path' => '/' . stripslashes( $name ) . '/' );
+
 		if ( ! empty( $path ) ) {
-			$data['path'] .= $path;
+			$data['path'] = $path . $data['path'];
 		}
-		$data['path'] .= '/' . stripslashes( $name ) . '/';
 
 		return $this->send_request( esc_url_raw( self::CMS_BASE_URL . $this->get_account_id() . '/labels/' ), 'POST', $data );
 	}
@@ -843,7 +844,7 @@ class BC_CMS_API extends BC_API {
 	 * @return mixed The request response.
 	 */
 	public function update_label( $name, $path ) {
-		$data['new_label'] = $name;
+		$data = array( 'new_label' => $name );
 		return $this->send_request( esc_url_raw( self::CMS_BASE_URL . $this->get_account_id() . '/labels/by_path/' . $path ), 'PATCH', $data );
 	}
 }


### PR DESCRIPTION
Prevents PHPCS warning: `Variable $data is undefined (VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable)`