### PR TITLE
Fix typo for the allowed tags global.

### DIFF
--- a/includes/class-bc-utility.php
+++ b/includes/class-bc-utility.php
@@ -459,7 +459,7 @@ class BC_Utility {
 
 	public static function admin_notice_messages( $notices ) {
 
-		global $allowed_tags;
+		global $allowedtags;
 
 		if ( empty( $notices ) ) {
 			return false;
@@ -468,7 +468,7 @@ class BC_Utility {
 		$html = '';
 		foreach ( $notices as $notice ) {
 			$html .= sprintf( '<div class="%1$s brightcove-settings-%1$s notice is-dismissible">', esc_attr( $notice['type'] ) );
-			$html .= sprintf( '<p>%s</p>', wp_kses( $notice['message'], $allowed_tags ) );
+			$html .= sprintf( '<p>%s</p>', wp_kses( $notice['message'], $allowedtags ) );
 			$html .= '</div>';
 		}
 


### PR DESCRIPTION
### Description of the Change

Fixed a typo in global keyword `$allowedtags`.

### Alternate Designs

n/a

### Benefits

Content in admin notices will be escaped properly.

### Possible Drawbacks

None.

### Verification Process

I was type-hinting the `apply_filters( 'wp_kses_allowed_html', $context, 'explicit' );` filter to accept `string|array` and PHP did throw a Fatal Error because of this typo. 
Fixing the typo also fixed this error.
See https://developer.wordpress.org/reference/functions/wp_kses_allowed_html/#source

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

n/a

### Changelog Entry

Fix: Fix typo for the `$allowedtags` global used in conjunction with `wp_kses`
