### PR TITLE
Fix Default Source field when is submitted unchecked

### DIFF
--- a/includes/admin/class-bc-admin-sources.php
+++ b/includes/admin/class-bc-admin-sources.php
@@ -284,9 +284,16 @@ class BC_Admin_Sources {
 					<tr class="brightcove-account-row">
 						<th scope="row"><?php esc_html_e( 'Default Source', 'brightcove' ) ?></th>
 						<td>
-							<input type="checkbox" <?php checked( 'on', $default_account ); ?>
-							       name="source-default-account" value="on">&nbsp;
-							<?php esc_html_e( 'Make this the default source for new users', 'brightcove' ); ?>
+							<label for="source-default-account">
+								<input
+									type="checkbox"
+									id="source-default-account"
+									name="source-default-account"
+									value="on"
+									<?php checked( 'on', $default_account ); ?>
+								>&nbsp;
+								<?php esc_html_e( 'Make this the default source for new users', 'brightcove' ); ?>
+							</label>
 						</td>
 					</tr>
 					</tbody>
@@ -340,9 +347,15 @@ class BC_Admin_Sources {
 					<tr class="brightcove-account-row">
 						<th scope="row"><?php esc_html_e( 'Default Source', 'brightcove' ) ?></th>
 						<td>
-							<input type="checkbox"
-							       name="source-default-account" <?php checked( get_option( '_brightcove_default_account' ), $account['hash'] ) ?> >&nbsp;
-							<?php esc_html_e( 'Make this the default source for new users', 'brightcove' ); ?>
+							<label for="source-default-account">
+								<input
+									type="checkbox"
+									id="source-default-account"
+									name="source-default-account"
+									<?php checked( get_option( '_brightcove_default_account' ), $account['hash'] ); ?> 
+								>&nbsp;
+								<?php esc_html_e( 'Make this the default source for new users', 'brightcove' ); ?>
+							</label>
 						</td>
 					</tr>
 				</table>

--- a/includes/admin/class-bc-admin-sources.php
+++ b/includes/admin/class-bc-admin-sources.php
@@ -147,8 +147,9 @@ class BC_Admin_Sources {
 
 			if ( isset( $_POST['source-default-account'] ) && 'on' === $_POST['source-default-account'] ) {
 				update_option( '_brightcove_default_account', sanitize_text_field( $_POST['hash'] ) );
+			} else {
+				delete_option( '_brightcove_default_account' );
 			}
-
 		}
 
 		// Deleting transient to allow syncing from the new account, otherwise we won't be able to sync it until this transient expires.


### PR DESCRIPTION
### Description of the Change

This change fixes the Default Source field when is submitted unchecked.

### Alternate Designs

### Benefits

### Possible Drawbacks

### Verification Process

1. Go to Brightcove -> Settings and edit a source
2. Check the field Default Source and save
3. Uncheck the field Default Source, save and see if the field is unchecked after form submission

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

### Changelog Entry

Fixed Default Source field when is submitted unchecked.
