### PR TITLE
Fix playlist preview in the editor

### DIFF
--- a/assets/js/src/block.js
+++ b/assets/js/src/block.js
@@ -180,7 +180,6 @@
 					'_default/index.html?videoId=' +
 					videoId;
 			} else {
-				playerId = bctiny.playlistEnabledPlayers[accountId][0] || 'default';
 				src =
 					'//players.brightcove.net/' +
 					accountId +

--- a/assets/js/src/tinymce.js
+++ b/assets/js/src/tinymce.js
@@ -231,8 +231,6 @@
 						playlistWidth = 500;
 					}
 
-					console.log({ self });
-
 					var player_id = self.shortcode.attrs.named.player_id || 'default';
 
 					var src =

--- a/assets/js/src/tinymce.js
+++ b/assets/js/src/tinymce.js
@@ -97,9 +97,7 @@
 					playlistWidth = 500;
 				}
 
-				var player_id =
-					bctiny.playlistEnabledPlayers[self.shortcode.attrs.named.account_id][0] ||
-					'default';
+				var player_id = self.shortcode.attrs.named.player_id || 'default';
 
 				var src =
 					'//players.brightcove.net/' +
@@ -233,10 +231,9 @@
 						playlistWidth = 500;
 					}
 
-					var player_id =
-						bctiny.playlistEnabledPlayers[
-							options.shortcode.attrs.named.account_id
-						][0] || 'default';
+					console.log({ self });
+
+					var player_id = self.shortcode.attrs.named.player_id || 'default';
 
 					var src =
 						'//players.brightcove.net/' +

--- a/includes/class-bc-setup.php
+++ b/includes/class-bc-setup.php
@@ -36,11 +36,6 @@ class BC_Setup {
 		new BC_Errors();
 
 		$bc_accounts = new BC_Accounts();
-		$players     = get_option( '_bc_player_playlist_ids_' . $bc_accounts->get_account_id() );
-
-		if ( false === $players || ! is_array( $players ) ) {
-			define( 'BRIGHTCOVE_FORCE_SYNC', true );
-		}
 
 		// Load Administrative Resources.
 		if ( BC_Utility::current_user_can_brightcove() ) {
@@ -300,7 +295,6 @@ class BC_Setup {
 	public static function admin_enqueue_scripts() {
 
 		global $wp_version;
-		global $bc_accounts;
 
 		// Use minified libraries if SCRIPT_DEBUG is turned off.
 		$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
@@ -330,20 +324,12 @@ class BC_Setup {
 
 		wp_register_script( 'brightcove', '//sadmin.brightcove.com/js/BrightcoveExperiences.js' );
 
-		$playlist_enabled_players_for_accounts = array();
-		$accounts                              = $bc_accounts->get_sanitized_all_accounts();
-
-		foreach ( $accounts as $account ) {
-			$playlist_enabled_players_for_accounts[ $account['account_id'] ] = get_option( '_bc_player_playlist_ids_' . $account['account_id'] );
-		}
-
 		wp_enqueue_script( 'tinymce_preview', esc_url( BRIGHTCOVE_URL . 'assets/js/src/tinymce.js' ), array( 'mce-view' ) );
 		wp_localize_script(
 			'tinymce_preview',
 			'bctiny',
 			array(
-				'wp_version'             => $wp_version,
-				'playlistEnabledPlayers' => $playlist_enabled_players_for_accounts,
+				'wp_version' => $wp_version,
 			)
 		);
 

--- a/includes/class-bc-utility.php
+++ b/includes/class-bc-utility.php
@@ -221,50 +221,6 @@ class BC_Utility {
 	}
 
 	/**
-	 * Function to delete players that are stored as an option.
-	 *
-	 * @param $ids_to_keep
-	 *
-	 * @return bool true if all options deleted, false on failure or non-existent player
-	 */
-	public static function remove_deleted_players( $ids_to_keep ) {
-
-		global $bc_accounts;
-		$all_ids_key = '_bc_player_ids_' . $bc_accounts->get_account_id();
-		$all_ids     = get_option( $all_ids_key );
-
-		$all_ids_playlists_key = '_bc_player_playlist_ids_' . $bc_accounts->get_account_id();
-		$all_ids_playlists     = get_option( $all_ids_playlists_key );
-
-		$return_state = true;
-
-		if ( is_array( $all_ids ) ) {
-			$ids_to_delete = array_diff( $all_ids, $ids_to_keep );
-
-			foreach ( $ids_to_delete as $id ) {
-				$key     = self::get_player_key( $id );
-				$success = delete_option( $key );
-				if ( ! $success ) {
-					$return_state = false;
-				}
-			}
-		}
-
-		if ( is_array( $all_ids_playlists ) ) {
-			foreach ( $all_ids_playlists as $id ) {
-				if ( in_array( $id, $all_ids_playlists ) ) {
-					unset( $all_ids_playlists[ $id ] );
-				}
-			}
-		}
-
-		update_option( $all_ids_key, $ids_to_keep );
-		update_option( $all_ids_playlists_key, $all_ids_playlists );
-
-		return $return_state;
-	}
-
-	/**
 	 * Sorts arrays, leaves objects as is.
 	 *
 	 * @param $object

--- a/includes/class-bc-utility.php
+++ b/includes/class-bc-utility.php
@@ -210,7 +210,6 @@ class BC_Utility {
 		// Delete account players
 		$player_ids = get_option( '_bc_player_ids_' . self::sanitize_id( $account_id ), array() );
 
-		delete_option( '_bc_player_playlist_ids_' . self::sanitize_id( $account_id ) );
 		delete_option( '_bc_player_ids_' . self::sanitize_id( $account_id ) );
 		foreach ( $player_ids as $player_id ) {
 			delete_option( '_bc_player_' . self::sanitize_player_id( $player_id ) . '_' . self::sanitize_id( $account_id ) );


### PR DESCRIPTION
### Description of the Change

When the user adds a playlist in the editor, the playlist is rendered using a video player. This change fixes the playlist preview to use a playlist player. 

### Alternate Designs

### Benefits

### Possible Drawbacks

### Verification Process

1. Add the Brightcove block and add a playlist
2. Check if the player utilized is a playlist player

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

Fixed playlist preview in the editor
