### PR TITLE
Update attribute type from int to string

### DIFF
--- a/includes/class-bc-setup.php
+++ b/includes/class-bc-setup.php
@@ -128,22 +128,22 @@ class BC_Setup {
 					'render_callback' => array( 'BC_Setup', 'render_shortcode' ),
 					'attributes'      => array(
 						'account_id'            => array(
-							'type' => 'int',
+							'type' => 'string',
 						),
 						'player_id'             => array(
 							'type' => 'string',
 						),
 						'video_id'              => array(
-							'type' => 'int',
+							'type' => 'string',
 						),
 						'playlist_id'           => array(
-							'type' => 'int',
+							'type' => 'string',
 						),
 						'experience_id'         => array(
 							'type' => 'string',
 						),
 						'video_ids'             => array(
-							'type' => 'int',
+							'type' => 'string',
 						),
 						'embed'                 => array(
 							'type' => 'string',


### PR DESCRIPTION
### Description of the Change

In WordPress 5.5, the type `int` is not one of the built-in types supported by WordPress. Since we're dealing with attributes in HTML the values are stored as strings and that way this PR changes the type from `int` to `string`

References:
- https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#attribute-source

### Alternate Designs

### Benefits

WordPress will not throw a warning when debug mode is enabled.

### Possible Drawbacks

Since `int` is not supported and the type falls back to `string`. So I believe we don’t need to make a kind of “migration” if we change to `string`.

### Verification Process

It can be verified by looking at the posts that have a video embedded and creating a post and adding a Brightcove block.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Closes #172 

### Changelog Entry

Fixed attributes type.
