### PR TITLE
Fixes playsinline not working with iframe elements

### DIFF
--- a/includes/class-bc-utility.php
+++ b/includes/class-bc-utility.php
@@ -1167,7 +1167,7 @@ class BC_Utility {
 						class="video-js"
 						controls <?php echo esc_attr( $playsinline ); ?> <?php echo esc_attr( $autoplay ); ?> <?php echo esc_attr( $mute ); ?>>
 				</video>
-				<script src="<?php esc_url( $src ); ?> "?>
+				<script src="<?php echo esc_url( $src ); ?>"?>
 				<div class="playlist-wrapper">
 					<ol class="vjs-playlist vjs-csspointerevents vjs-mouse"> </ol>
 				</div>

--- a/includes/class-bc-utility.php
+++ b/includes/class-bc-utility.php
@@ -877,7 +877,7 @@ class BC_Utility {
 
 		<?php
 		if ( 'javascript' === $embed ) :
-			$js_src = self::build_brightcove_src( $account_id, '/experience_' . $experience_id . '/live.js' );
+			$js_src = self::build_brightcove_src( $account_id, 'experience_' . $experience_id . '/live.js' );
 			?>
 			<div data-experience="<?php echo esc_attr( $experience_id ); ?>"
 				<?php echo $js_attr; // phpcs:ignore ?> data-usage="cms:WordPress:<?php echo esc_attr( $wp_version ); ?>:<?php echo esc_attr( BRIGHTCOVE_VERSION ); ?>:experiencejavascript" style="display: block; position: relative; min-width: <?php echo esc_attr( $min_width ); ?> max-width: <?php echo esc_attr( $max_width ); ?>; width: <?php echo esc_attr( $width ); ?>; height: <?php echo esc_attr( $height ); ?>;">
@@ -885,7 +885,7 @@ class BC_Utility {
 			<script src="<?php echo esc_url( $js_src ); ?>"></script> <?php // phpcs:ignore ?>
 			<?php
 		else :
-			$iframe_src = self::build_brightcove_src( $account_id, '/experience_' . $experience_id . '/index.html?cms:WordPress:' . $wp_version . ':' . BRIGHTCOVE_VERSION . ':experienceiframe&' . $url_attr );
+			$iframe_src = self::build_brightcove_src( $account_id, 'experience_' . $experience_id . '/index.html?cms:WordPress:' . $wp_version . ':' . BRIGHTCOVE_VERSION . ':experienceiframe&' . $url_attr );
 			?>
 
 			<div style="display: block; position: relative; width: <?php echo esc_attr( $width ); ?>; height: <?php echo esc_attr( $height ); ?>;">
@@ -953,7 +953,7 @@ class BC_Utility {
 		<?php
 
 		if ( 'in-page' === $embed ) :
-			$js_src = self::build_brightcove_src( $account_id, '/' . $player_id . '_default/index.min.js' );
+			$js_src = self::build_brightcove_src( $account_id, $player_id . '_default/index.min.js' );
 			if ( 'pictureinpicture' === $atts['picture_in_picture'] ) :
 				?>
 				<!-- The picture-in-picture container. This is required! -->
@@ -1037,7 +1037,7 @@ class BC_Utility {
 
 			$iframe_src = self::build_brightcove_src(
 				$account_id,
-				'/' . $player_id . '_default/index.html?videoId=' . $id . '&usage=' . self::get_usage_data() . 'iframe' . $playsinline . $autoplay . $mute
+				$player_id . '_default/index.html?videoId=' . $id . '&usage=' . self::get_usage_data() . 'iframe' . $playsinline . $autoplay . $mute
 			);
 			?>
 
@@ -1115,7 +1115,7 @@ class BC_Utility {
 		<!-- Start of Brightcove Player -->
 
 		<?php if ( 'in-page-vertical' === $embed ) : ?>
-			<?php $src = self::build_brightcove_src( $account_id, '/' . $player_id . '_default/index.min.js' ); ?>
+			<?php $src = self::build_brightcove_src( $account_id, $player_id . '_default/index.min.js' ); ?>
 			<style type="text/css">
 				.video-js {
 					width: <?php echo esc_attr( $width ); ?>;
@@ -1175,7 +1175,7 @@ class BC_Utility {
 			</div>
 
 		<?php elseif ( 'in-page-horizontal' === $embed ) : ?>
-			<?php $src = self::build_brightcove_src( $account_id, '/' . $player_id . '_default/index.min.js' ); ?>
+			<?php $src = self::build_brightcove_src( $account_id, $player_id . '_default/index.min.js' ); ?>
 			<style type="text/css">
 				.video-js {
 					width: <?php echo esc_attr( $width ); ?>;
@@ -1242,7 +1242,7 @@ class BC_Utility {
 				$mute = '&' . $mute;
 			}
 
-			$iframesrc = self::build_brightcove_src( $account_id, '/' . $player_id . '_default/index.html?playlistId=' . $id . '&usage=' . self::get_usage_data() . 'iframe' . $playsinline . $autoplay . $mute );
+			$iframesrc = self::build_brightcove_src( $account_id, $player_id . '_default/index.html?playlistId=' . $id . '&usage=' . self::get_usage_data() . 'iframe' . $playsinline . $autoplay . $mute );
 			?>
 
 			<div style="display: block; position: relative; min-width: <?php echo esc_attr( $min_width ); ?>; max-width: <?php echo esc_attr( $max_width ); ?>;">
@@ -1263,7 +1263,7 @@ class BC_Utility {
 			<?php endif; ?>
 
 			<?php
-			$src = self::build_brightcove_src( $account_id, '/' . $player_id . '_default/index.html?playlistId= /&' . $id . '&' . self::get_usage_data() . 'iframe' );
+			$src = self::build_brightcove_src( $account_id, $player_id . '_default/index.html?playlistId= /&' . $id . '&' . self::get_usage_data() . 'iframe' );
 			printf(
 				'<iframe src="%s" allowfullscreen="" webkitallowfullscreen="" mozallowfullscreen="" style="width: %s; height: %s;%s"></iframe>',
 				esc_url( $src ),
@@ -1523,6 +1523,6 @@ class BC_Utility {
 	 * @return string
 	 */
 	public static function build_brightcove_src( $account_id, $extra_params = '' ) {
-		return 'https://players.brightcove.net/' . $account_id . $extra_params;
+		return 'https://players.brightcove.net/' . trailingslashit( $account_id ) . $extra_params;
 	}
 }

--- a/includes/class-bc-utility.php
+++ b/includes/class-bc-utility.php
@@ -877,7 +877,7 @@ class BC_Utility {
 
 		<?php
 		if ( 'javascript' === $embed ) :
-			$js_src = 'https://players.brightcove.net/' . $account_id . '/experience_' . $experience_id . '/live.js';
+			$js_src = self::build_brightcove_src( $account_id, '/experience_' . $experience_id . '/live.js' );
 			?>
 			<div data-experience="<?php echo esc_attr( $experience_id ); ?>"
 				<?php echo $js_attr; // phpcs:ignore ?> data-usage="cms:WordPress:<?php echo esc_attr( $wp_version ); ?>:<?php echo esc_attr( BRIGHTCOVE_VERSION ); ?>:experiencejavascript" style="display: block; position: relative; min-width: <?php echo esc_attr( $min_width ); ?> max-width: <?php echo esc_attr( $max_width ); ?>; width: <?php echo esc_attr( $width ); ?>; height: <?php echo esc_attr( $height ); ?>;">
@@ -885,7 +885,7 @@ class BC_Utility {
 			<script src="<?php echo esc_url( $js_src ); ?>"></script> <?php // phpcs:ignore ?>
 			<?php
 		else :
-			$iframe_src = 'https://players.brightcove.net/' . $account_id . '/experience_' . $experience_id . '/index.html?cms:WordPress:' . $wp_version . ':' . BRIGHTCOVE_VERSION . ':experienceiframe&' . $url_attr;
+			$iframe_src = self::build_brightcove_src( $account_id, '/experience_' . $experience_id . '/index.html?cms:WordPress:' . $wp_version . ':' . BRIGHTCOVE_VERSION . ':experienceiframe&' . $url_attr );
 			?>
 
 			<div style="display: block; position: relative; width: <?php echo esc_attr( $width ); ?>; height: <?php echo esc_attr( $height ); ?>;">
@@ -953,7 +953,7 @@ class BC_Utility {
 		<?php
 
 		if ( 'in-page' === $embed ) :
-			$js_src = 'https://players.brightcove.net/' . $account_id . '/' . $player_id . '_default/index.min.js';
+			$js_src = self::build_brightcove_src( $account_id, '/' . $player_id . '_default/index.min.js' );
 			if ( 'pictureinpicture' === $atts['picture_in_picture'] ) :
 				?>
 				<!-- The picture-in-picture container. This is required! -->
@@ -1030,7 +1030,10 @@ class BC_Utility {
 			if ( ! empty( $mute ) ) {
 				$mute = '&' . $mute;
 			}
-			$iframe_src = 'https://players.brightcove.net/' . $account_id . '/' . $player_id . '_default/index.html?videoId=' . $id . '&usage=' . self::get_usage_data() . 'iframe' . $autoplay . $mute;
+
+			$iframe_src = self::build_brightcove_src(
+					$account_id,
+					'/' . $player_id . '_default/index.html?videoId=' . $id . '&usage=' . self::get_usage_data() . 'iframe' . $autoplay . $mute );
 			?>
 
 			<div style="display: block; position: relative; min-width: <?php echo esc_attr( $min_width ); ?>; max-width: <?php echo esc_attr( $max_width ); ?>;">
@@ -1107,6 +1110,7 @@ class BC_Utility {
 		<!-- Start of Brightcove Player -->
 
 		<?php if ( 'in-page-vertical' === $embed ) : ?>
+        <?php $src = self::build_brightcove_src( $account_id, '/' . $player_id . '_default/index.min.js' ); ?>
 			<style type="text/css">
 				.video-js {
 					width: <?php echo esc_attr( $width ); ?>;
@@ -1159,13 +1163,14 @@ class BC_Utility {
 						class="video-js"
 						controls <?php echo esc_attr( $playsinline ); ?> <?php echo esc_attr( $autoplay ); ?> <?php echo esc_attr( $mute ); ?>>
 				</video>
-				<script src="//players.brightcove.net/<?php echo esc_attr( $account_id ); ?>/<?php echo esc_attr( $player_id ); ?>_default/index.min.js"></script> <?php // phpcs:ignore ?>
+				<script src="<?php esc_url( $src ); ?> "?>
 				<div class="playlist-wrapper">
 					<ol class="vjs-playlist vjs-csspointerevents vjs-mouse"> </ol>
 				</div>
 			</div>
 
 		<?php elseif ( 'in-page-horizontal' === $embed ) : ?>
+		<?php $src = self::build_brightcove_src( $account_id, '/' . $player_id . '_default/index.min.js' ); ?>
 			<style type="text/css">
 				.video-js {
 					width: <?php echo esc_attr( $width ); ?>;
@@ -1214,7 +1219,7 @@ class BC_Utility {
 						class="video-js"
 						controls <?php echo esc_attr( $autoplay ); ?> <?php echo esc_attr( $mute ); ?>>
 				</video>
-				<script src="//players.brightcove.net/<?php echo esc_attr( $account_id ); ?>/<?php echo esc_attr( $player_id ); ?>_default/index.min.js"></script> <?php // phpcs:ignore ?>
+				<script src="<?php echo esc_url( $src ); ?>"></script>
 				<div class="playlist-wrapper">
 					<ol class="vjs-playlist vjs-csspointerevents vjs-mouse"> </ol>
 				</div>
@@ -1227,7 +1232,8 @@ class BC_Utility {
 			if ( ! empty( $mute ) ) {
 				$mute = '&' . $mute;
 			}
-			$iframesrc = 'https://players.brightcove.net/' . $account_id . '/' . $player_id . '_default/index.html?playlistId=' . $id . '&usage=' . self::get_usage_data() . 'iframe' . $autoplay . $mute;
+
+			$iframesrc = self::build_brightcove_src( $account_id, '/' . $player_id . '_default/index.html?playlistId=' . $id . '&usage=' . self::get_usage_data() . 'iframe' . $autoplay . $mute );
 			?>
 
 			<div style="display: block; position: relative; min-width: <?php echo esc_attr( $min_width ); ?>; max-width: <?php echo esc_attr( $max_width ); ?>;">
@@ -1248,13 +1254,10 @@ class BC_Utility {
 			<?php endif; ?>
 
 			<?php
+			$src = self::build_brightcove_src( $account_id, '/' . $player_id . '_default/index.html?playlistId= /&' . $id . '&' . self::get_usage_data() . 'iframe' );
 			printf(
-				'<iframe src="//players.brightcove.net/%s/%s_default/index.html?%sId=%s&%s" allowfullscreen="" webkitallowfullscreen="" mozallowfullscreen="" style="width: %s; height: %s;%s"></iframe>',
-				$account_id,
-				$player_id,
-				'playlist',
-				$id,
-				esc_attr( self::get_usage_data() ) . 'iframe',
+				'<iframe src="%s" allowfullscreen="" webkitallowfullscreen="" mozallowfullscreen="" style="width: %s; height: %s;%s"></iframe>',
+                esc_url( $src ),
 				( '0' === $width ) ? '100%' : esc_attr( $width ) . 'px', // phpcs:ignore
 				( '0' === $height ) ? '100%' : esc_attr( $height ) . 'px', // phpcs:ignore
 				( '0' === $width && '0' === $height ) ? 'position: absolute; top: 0px; bottom: 0px; right: 0px; left: 0px;' : '' // phpcs:ignore
@@ -1501,5 +1504,16 @@ class BC_Utility {
 	 */
 	public static function compare_player_update_date( $player1, $player2 ) {
 		return strtotime( $player1['branches']['master']['updated_at'] ) < strtotime( $player2['branches']['master']['updated_at'] ) ? 1 : -1;
+	}
+
+	/**
+	 * Builds a URL based on a common player src.
+	 *
+	 * @param $account_id
+	 * @param $extra_params
+	 * @return string
+	 */
+	public static function build_brightcove_src( $account_id, $extra_params = '' ) {
+		return 'https://players.brightcove.net/' . $account_id . $extra_params;
 	}
 }

--- a/includes/class-bc-utility.php
+++ b/includes/class-bc-utility.php
@@ -1036,8 +1036,9 @@ class BC_Utility {
 			}
 
 			$iframe_src = self::build_brightcove_src(
-					$account_id,
-					'/' . $player_id . '_default/index.html?videoId=' . $id . '&usage=' . self::get_usage_data() . 'iframe' . $playsinline . $autoplay . $mute );
+				$account_id,
+				'/' . $player_id . '_default/index.html?videoId=' . $id . '&usage=' . self::get_usage_data() . 'iframe' . $playsinline . $autoplay . $mute
+			);
 			?>
 
 			<div style="display: block; position: relative; min-width: <?php echo esc_attr( $min_width ); ?>; max-width: <?php echo esc_attr( $max_width ); ?>;">
@@ -1114,7 +1115,7 @@ class BC_Utility {
 		<!-- Start of Brightcove Player -->
 
 		<?php if ( 'in-page-vertical' === $embed ) : ?>
-        <?php $src = self::build_brightcove_src( $account_id, '/' . $player_id . '_default/index.min.js' ); ?>
+			<?php $src = self::build_brightcove_src( $account_id, '/' . $player_id . '_default/index.min.js' ); ?>
 			<style type="text/css">
 				.video-js {
 					width: <?php echo esc_attr( $width ); ?>;
@@ -1167,14 +1168,14 @@ class BC_Utility {
 						class="video-js"
 						controls <?php echo esc_attr( $playsinline ); ?> <?php echo esc_attr( $autoplay ); ?> <?php echo esc_attr( $mute ); ?>>
 				</video>
-				<script src="<?php echo esc_url( $src ); ?>"?>
+				<script src="<?php echo esc_url( $src ); ?>"><?php //phpcs:ignore WordPress.WP.EnqueuedResources ?>
 				<div class="playlist-wrapper">
 					<ol class="vjs-playlist vjs-csspointerevents vjs-mouse"> </ol>
 				</div>
 			</div>
 
 		<?php elseif ( 'in-page-horizontal' === $embed ) : ?>
-		<?php $src = self::build_brightcove_src( $account_id, '/' . $player_id . '_default/index.min.js' ); ?>
+			<?php $src = self::build_brightcove_src( $account_id, '/' . $player_id . '_default/index.min.js' ); ?>
 			<style type="text/css">
 				.video-js {
 					width: <?php echo esc_attr( $width ); ?>;
@@ -1223,7 +1224,7 @@ class BC_Utility {
 						class="video-js"
 						controls <?php echo esc_attr( $autoplay ); ?> <?php echo esc_attr( $mute ); ?>>
 				</video>
-				<script src="<?php echo esc_url( $src ); ?>"></script>
+				<script src="<?php echo esc_url( $src ); ?>"></script><?php //phpcs:ignore WordPress.WP.EnqueuedResources ?>
 				<div class="playlist-wrapper">
 					<ol class="vjs-playlist vjs-csspointerevents vjs-mouse"> </ol>
 				</div>
@@ -1265,7 +1266,7 @@ class BC_Utility {
 			$src = self::build_brightcove_src( $account_id, '/' . $player_id . '_default/index.html?playlistId= /&' . $id . '&' . self::get_usage_data() . 'iframe' );
 			printf(
 				'<iframe src="%s" allowfullscreen="" webkitallowfullscreen="" mozallowfullscreen="" style="width: %s; height: %s;%s"></iframe>',
-                esc_url( $src ),
+				esc_url( $src ),
 				( '0' === $width ) ? '100%' : esc_attr( $width ) . 'px', // phpcs:ignore
 				( '0' === $height ) ? '100%' : esc_attr( $height ) . 'px', // phpcs:ignore
 				( '0' === $width && '0' === $height ) ? 'position: absolute; top: 0px; bottom: 0px; right: 0px; left: 0px;' : '' // phpcs:ignore
@@ -1517,8 +1518,8 @@ class BC_Utility {
 	/**
 	 * Builds a URL based on a common player src.
 	 *
-	 * @param $account_id
-	 * @param $extra_params
+	 * @param int    $account_id The brightcove account id.
+	 * @param string $extra_params Extra params to append.
 	 * @return string
 	 */
 	public static function build_brightcove_src( $account_id, $extra_params = '' ) {

--- a/includes/class-bc-utility.php
+++ b/includes/class-bc-utility.php
@@ -1024,6 +1024,10 @@ class BC_Utility {
 				<?php
 			endif;
 		elseif ( 'iframe' === $embed ) :
+
+			if ( ! empty( $playsinline ) ) {
+				$playsinline = '&' . $playsinline;
+			}
 			if ( ! empty( $autoplay ) ) {
 				$autoplay = '&' . $autoplay;
 			}
@@ -1033,7 +1037,7 @@ class BC_Utility {
 
 			$iframe_src = self::build_brightcove_src(
 					$account_id,
-					'/' . $player_id . '_default/index.html?videoId=' . $id . '&usage=' . self::get_usage_data() . 'iframe' . $autoplay . $mute );
+					'/' . $player_id . '_default/index.html?videoId=' . $id . '&usage=' . self::get_usage_data() . 'iframe' . $playsinline . $autoplay . $mute );
 			?>
 
 			<div style="display: block; position: relative; min-width: <?php echo esc_attr( $min_width ); ?>; max-width: <?php echo esc_attr( $max_width ); ?>;">
@@ -1226,6 +1230,10 @@ class BC_Utility {
 			</div>
 		<?php elseif ( 'iframe' === $embed ) : ?>
 			<?php
+
+			if ( ! empty( $playsinline ) ) {
+				$playsinline = '&' . $playsinline;
+			}
 			if ( ! empty( $autoplay ) ) {
 				$autoplay = '&' . $autoplay;
 			}
@@ -1233,7 +1241,7 @@ class BC_Utility {
 				$mute = '&' . $mute;
 			}
 
-			$iframesrc = self::build_brightcove_src( $account_id, '/' . $player_id . '_default/index.html?playlistId=' . $id . '&usage=' . self::get_usage_data() . 'iframe' . $autoplay . $mute );
+			$iframesrc = self::build_brightcove_src( $account_id, '/' . $player_id . '_default/index.html?playlistId=' . $id . '&usage=' . self::get_usage_data() . 'iframe' . $playsinline . $autoplay . $mute );
 			?>
 
 			<div style="display: block; position: relative; min-width: <?php echo esc_attr( $min_width ); ?>; max-width: <?php echo esc_attr( $max_width ); ?>;">


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
* Fixes playsinline not working with iframe elements. 
* It also adds a new method to build a common src url needed for iframe and video-js elements https://github.com/10up/brightcove-video-connect/pull/313/files#diff-a7e290eaff3f36e927ee0bf922391369318ce128aa6daba790b4898e13451cb7R1525

<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
