### PR TITLE
Bugfix:  Prevent API calls when Brightcove has not been configured yet

### DIFF
--- a/brightcove-video-connect.php
+++ b/brightcove-video-connect.php
@@ -52,7 +52,6 @@ function brightcove_activate() {
  * Uninstall routines should be in uninstall.php
  */
 function brightcove_deactivate() {
-
 	BC_Utility::deactivate();
 }
 

--- a/includes/class-bc-setup.php
+++ b/includes/class-bc-setup.php
@@ -334,8 +334,8 @@ class BC_Setup {
 		$params['mimeTypes'] = BC_Utility::get_all_brightcove_mimetypes();
 
 		$default_account            = $bc_accounts->get_account_details_for_user();
-		$params['defaultAccount']   = ! empty ( $default_account['hash'] ) ? $default_account['hash'] : '';
-		$params['defaultAccountId'] = ! empty ( $default_account['account_id'] ) ? $default_account['account_id'] : '';
+		$params['defaultAccount']   = ! empty( $default_account['hash'] ) ? $default_account['hash'] : '';
+		$params['defaultAccountId'] = ! empty( $default_account['account_id'] ) ? $default_account['account_id'] : '';
 
 		return $params;
 

--- a/includes/class-bc-setup.php
+++ b/includes/class-bc-setup.php
@@ -345,7 +345,7 @@ class BC_Setup {
 	}
 
 	/**
-	 *
+	 * Enqueue brightcove functionality dependent assets.
 	 *
 	 * @return void
 	 */

--- a/includes/class-bc-setup.php
+++ b/includes/class-bc-setup.php
@@ -53,9 +53,9 @@ class BC_Setup {
 		// Load Administrative Resources.
 		if ( BC_Utility::current_user_can_brightcove() ) {
 			require_once BRIGHTCOVE_PATH . 'includes/admin/class-bc-admin-settings-page.php';
-            require_once BRIGHTCOVE_PATH . 'includes/admin/class-bc-admin-sources.php';
+			require_once BRIGHTCOVE_PATH . 'includes/admin/class-bc-admin-sources.php';
 			new BC_Admin_Settings_Page();
-            new BC_Admin_Sources();
+			new BC_Admin_Sources();
 
 			if ( get_option( '_brightcove_accounts' ) ) {
 				require_once BRIGHTCOVE_PATH . 'includes/admin/class-bc-admin-labels-page.php';
@@ -344,78 +344,78 @@ class BC_Setup {
 
 	}
 
-    /**
-     *
-     *
-     * @return void
-     */
-    public static function brightcove_enqueue_assets() {
-        global $wp_version;
+	/**
+	 *
+	 *
+	 * @return void
+	 */
+	public static function brightcove_enqueue_assets() {
+		global $wp_version;
 
-        $suffix = BC_Utility::get_suffix();
+		$suffix = BC_Utility::get_suffix();
 
-        $player_api = new BC_Player_Management_API2();
-        $players    = $player_api->get_all_players();
+		$player_api = new BC_Player_Management_API2();
+		$players    = $player_api->get_all_players();
 
-        $experiences_api = new BC_Experiences_API();
-        $experiences     = $experiences_api->get_experiences();
+		$experiences_api = new BC_Experiences_API();
+		$experiences     = $experiences_api->get_experiences();
 
-        $js_variable = array(
-            'path'           => esc_url( BRIGHTCOVE_URL . 'assets/js/src/' ),
-            'preload'        => self::preload_params(),
-            'wp_version'     => $wp_version,
-            'languages'      => BC_Utility::languages(),
-            'players'        => $players,
-            'experiences'    => $experiences,
-            'str_badformat'  => esc_html__( 'This file is not the proper format. Please use .vtt files, for more information visit', 'brightcove' ),
-            'badformat_link' => esc_url( 'https://support.brightcove.com/en/video-cloud/docs/adding-captions-videos#captionsfile' ),
-            'str_addcaption' => esc_html__( 'Add Another Caption', 'brightcove' ),
-            'str_addremote'  => esc_html__( 'Add another remote file', 'brightcove' ),
-            'str_selectfile' => esc_html__( 'Select File', 'brightcove' ),
-            'str_useremote'  => esc_html__( 'Use a remote file instead', 'brightcove' ),
-            'str_apifailure' => esc_html__( "Sorry! We weren't able to reach the Brightcove API even after trying a few times. Please try refreshing the page.", 'brightcove' ),
-            'posts_per_page' => absint( apply_filters( 'brightcove_posts_per_page', 100 ) ), // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page
-        );
+		$js_variable = array(
+			'path'           => esc_url( BRIGHTCOVE_URL . 'assets/js/src/' ),
+			'preload'        => self::preload_params(),
+			'wp_version'     => $wp_version,
+			'languages'      => BC_Utility::languages(),
+			'players'        => $players,
+			'experiences'    => $experiences,
+			'str_badformat'  => esc_html__( 'This file is not the proper format. Please use .vtt files, for more information visit', 'brightcove' ),
+			'badformat_link' => esc_url( 'https://support.brightcove.com/en/video-cloud/docs/adding-captions-videos#captionsfile' ),
+			'str_addcaption' => esc_html__( 'Add Another Caption', 'brightcove' ),
+			'str_addremote'  => esc_html__( 'Add another remote file', 'brightcove' ),
+			'str_selectfile' => esc_html__( 'Select File', 'brightcove' ),
+			'str_useremote'  => esc_html__( 'Use a remote file instead', 'brightcove' ),
+			'str_apifailure' => esc_html__( "Sorry! We weren't able to reach the Brightcove API even after trying a few times. Please try refreshing the page.", 'brightcove' ),
+			'posts_per_page' => absint( apply_filters( 'brightcove_posts_per_page', 100 ) ), // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page
+		);
 
-        wp_register_script( 'brightcove', '//sadmin.brightcove.com/js/BrightcoveExperiences.js', array(), BRIGHTCOVE_VERSION, false );
+		wp_register_script( 'brightcove', '//sadmin.brightcove.com/js/BrightcoveExperiences.js', array(), BRIGHTCOVE_VERSION, false );
 
-        wp_enqueue_script( 'tinymce_preview', esc_url( BRIGHTCOVE_URL . 'assets/js/src/tinymce.js' ), array( 'mce-view' ), BRIGHTCOVE_VERSION, true );
-        wp_localize_script(
-            'tinymce_preview',
-            'bctiny',
-            array(
-                'wp_version' => $wp_version,
-            )
-        );
+		wp_enqueue_script( 'tinymce_preview', esc_url( BRIGHTCOVE_URL . 'assets/js/src/tinymce.js' ), array( 'mce-view' ), BRIGHTCOVE_VERSION, true );
+		wp_localize_script(
+			'tinymce_preview',
+			'bctiny',
+			array(
+				'wp_version' => $wp_version,
+			)
+		);
 
-        $dependencies = array(
-            'jquery-ui-autocomplete',
-            'jquery',
-            'backbone',
-            'wp-backbone',
-            'media',
-            'media-editor',
-            'media-grid',
-            'media-models',
-            'media-upload',
-            'media-views',
-            'plupload-all',
-            'brightcove',
-            'wp-mediaelement',
-            'tinymce_preview',
-            'jquery-ui-datepicker',
-        );
+		$dependencies = array(
+			'jquery-ui-autocomplete',
+			'jquery',
+			'backbone',
+			'wp-backbone',
+			'media',
+			'media-editor',
+			'media-grid',
+			'media-models',
+			'media-upload',
+			'media-views',
+			'plupload-all',
+			'brightcove',
+			'wp-mediaelement',
+			'tinymce_preview',
+			'jquery-ui-datepicker',
+		);
 
-        wp_register_script( 'brightcove-admin', esc_url( BRIGHTCOVE_URL . 'assets/js/brightcove-admin' . $suffix . '.js' ), $dependencies, BRIGHTCOVE_VERSION, true );
-        wp_localize_script( 'brightcove-admin', 'wpbc', $js_variable );
-        wp_enqueue_script( 'brightcove-admin' );
+		wp_register_script( 'brightcove-admin', esc_url( BRIGHTCOVE_URL . 'assets/js/brightcove-admin' . $suffix . '.js' ), $dependencies, BRIGHTCOVE_VERSION, true );
+		wp_localize_script( 'brightcove-admin', 'wpbc', $js_variable );
+		wp_enqueue_script( 'brightcove-admin' );
 
-        if ( isset( $GLOBALS['post_ID'] ) ) {
-            wp_enqueue_media( array( 'post' => $GLOBALS['post_ID'] ) );
-        } else {
-            wp_enqueue_media();
-        }
-    }
+		if ( isset( $GLOBALS['post_ID'] ) ) {
+			wp_enqueue_media( array( 'post' => $GLOBALS['post_ID'] ) );
+		} else {
+			wp_enqueue_media();
+		}
+	}
 
 	/**
 	 * Enqueue the admin scripts and styles.

--- a/includes/class-bc-setup.php
+++ b/includes/class-bc-setup.php
@@ -48,7 +48,7 @@ class BC_Setup {
 		// Preload Errors Class First.
 		new BC_Errors();
 
-		$bc_accounts = new BC_Accounts();
+		$bc_accounts = ! get_option( '_brightcove_accounts' ) ? new BC_Accounts() : false;
 
 		// Load Administrative Resources.
 		if ( BC_Utility::current_user_can_brightcove() ) {
@@ -334,8 +334,8 @@ class BC_Setup {
 		$params['mimeTypes'] = BC_Utility::get_all_brightcove_mimetypes();
 
 		$default_account            = $bc_accounts->get_account_details_for_user();
-		$params['defaultAccount']   = $default_account['hash'];
-		$params['defaultAccountId'] = $default_account['account_id'];
+		$params['defaultAccount']   = ! empty ( $default_account['hash'] ) ? $default_account['hash'] : '';
+		$params['defaultAccountId'] = ! empty ( $default_account['account_id'] ) ? $default_account['account_id'] : '';
 
 		return $params;
 

--- a/includes/class-bc-utility.php
+++ b/includes/class-bc-utility.php
@@ -1525,4 +1525,13 @@ class BC_Utility {
 	public static function build_brightcove_src( $account_id, $extra_params = '' ) {
 		return 'https://players.brightcove.net/' . trailingslashit( $account_id ) . $extra_params;
 	}
+
+	/**
+	 * Utility function to get suffix for assets. For development purposes.
+	 *
+	 * @return string
+	 */
+	public static function get_suffix() {
+		return ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
+	}
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR checks if the Brightcove accounts have been set, and if they are not, it prevents loading code that doesn't make sense to be loaded before.

The fix specifically targets #198 and #231 where remote requests are being fired. It doesn't make sense to fire these if the plugin has not been configured with a valid Brightcove Account first. 

It also solves a bug related to the account data when we do not have that yet. 

<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #198 
Closes #231

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed -  Prevent API calls when Brightcove has not been configured yet


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @oscarssanchez 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
