### PR TITLE
Fix: Playlists have empty "Created At:" and "Updated At:"

### DIFF
--- a/assets/js/src/views/media-details.js
+++ b/assets/js/src/views/media-details.js
@@ -526,8 +526,8 @@ var MediaDetailsView = BrightcoveView.extend({
 		options = _.extend({}, options, this.model.toJSON());
 		// options.duration = this.model.getReadableDuration();
 		options.duration = '0:05';
-		options.updated_at_readable = this.model.getReadableDate('updatedAt');
-		options.created_at_readable = this.model.getReadableDate('createdAt');
+		options.updated_at_readable = this.model.getReadableDate('updated_at');
+		options.created_at_readable = this.model.getReadableDate('created_at');
 		options.account_name = this.model.getAccountName();
 
 		this.template = wp.template('brightcove-media-item-details-' + this.mediaType);


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes an issue where the playlists have empty "Created At:" and "Updated At:"

<img width="333" alt="image" src="https://github.com/10up/brightcove-video-connect/assets/7139602/47cbe835-33ec-445a-a39f-ff0c27864a85">



<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #347 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Click on the playlist and check if "Created At:" and "Updated At:" are not empty

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Playlists have empty "Created At:" and "Updated At:"



### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy @felipeelia 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
