### PR TITLE
Fix caption upload issue

### DIFF
--- a/includes/admin/api/class-bc-admin-media-api.php
+++ b/includes/admin/api/class-bc-admin-media-api.php
@@ -939,7 +939,7 @@ class BC_Admin_Media_API {
 			$default = ( isset( $caption['default'] ) && 'checked' === $caption['default'] );
 
 			$source = wp_parse_url( $caption['source'] );
-			if ( 0 === strpos( $source['host'], 'brightcove' ) ) {
+			if ( 0 === strpos( $source['host'], 'brightcove' ) && false === strpos( $source['host'], '.test' ) ) {
 				// If the hostname starts with "brightcove," assume this media has already been ingested and add to old captions.
 				$old_captions[] = new BC_Text_Track( $url, $lang, 'captions', $label, $default );
 				continue;
@@ -957,10 +957,14 @@ class BC_Admin_Media_API {
 		}
 
 		// Push the new captions to Brightcove
-		$this->cms_api->text_track_upload( $video_id, $new_captions );
+		$has_caption_uploaded = $this->cms_api->text_track_upload( $video_id, $new_captions );
 
 		// Restore our global, default account
 		$bc_accounts->restore_default_account();
+
+		if ( false === $has_caption_uploaded ) {
+			wp_send_json_error( esc_html__( 'Failed to upload caption.', 'brightcove' ) );
+		}
 	}
 
 	/**

--- a/includes/api/class-bc-text-track.php
+++ b/includes/api/class-bc-text-track.php
@@ -21,7 +21,7 @@ class BC_Text_Track {
 	 *
 	 * @var string
 	 */
-	protected $src_lang;
+	protected $srclang;
 
 	/**
 	 * How the VTT file is meant to be used
@@ -61,8 +61,8 @@ class BC_Text_Track {
 	 * @param bool   $default  Set the default language for captions/subtitles
 	 */
 	public function __construct( $url, $language = 'en-US', $kind = 'captions', $label = '', $default = false ) {
-		$this->url      = esc_url_raw( $url );
-		$this->src_lang = sanitize_text_field( $language );
+		$this->url     = esc_url_raw( $url );
+		$this->srclang = sanitize_text_field( $language );
 		if ( ! in_array( $kind, array( 'captions', 'subtitles', 'descriptions', 'chapters', 'metadata' ), true ) ) {
 			$this->kind = 'captions';
 		} else {
@@ -79,10 +79,10 @@ class BC_Text_Track {
 	 */
 	public function to_array() {
 		$data = array(
-			'url'      => $this->url,
-			'src_lang' => $this->src_lang,
-			'kind'     => $this->kind,
-			'default'  => $this->default,
+			'url'     => $this->url,
+			'srclang' => $this->srclang,
+			'kind'    => $this->kind,
+			'default' => $this->default,
 		);
 
 		if ( ! empty( $this->label ) ) {
@@ -100,7 +100,7 @@ class BC_Text_Track {
 	public function to_array_patch() {
 		$data = array(
 			'src'       => $this->url,
-			'src_lang'  => $this->src_lang,
+			'srclang'   => $this->srclang,
 			'kind'      => $this->kind,
 			'default'   => $this->default,
 			'mime_type' => $this->mime_type,


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes an issue where the caption was not uploading in the brightcove. 


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

- Upload the caption for the video
- Make sure it ends successfully

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Caption upload issue
 


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy @felipeelia 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
