### PR TITLE
Register Brightcove block in Media category

### DIFF
--- a/assets/js/src/block.js
+++ b/assets/js/src/block.js
@@ -19,7 +19,7 @@
 			'brightcove',
 		),
 		icon: 'video-alt3',
-		category: 'common',
+		category: 'media',
 		supports: {
 			inserter: userPermission,
 			html: false,


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR changes the registration of the `bc/brightcove` block from the `common` category - shown as _Text_ in the block inserter - to the _Media_ category.

![Screenshot 2023-12-08 at 15 44 26](https://github.com/10up/brightcove-video-connect/assets/95643968/6e02d5ba-4900-414d-b351-bd09ab4090c8)

Closes https://github.com/10up/brightcove-video-connect/issues/363

### How to test the Change

1. In a post, in the block inserter check that Brightcove block appears under _Media_ category.

### Changelog Entry
> Changed - Registration of `bc/brightcove` from `common` to `media`.

### Credits
Props @mattradford

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests pass.
