### PR TITLE
Don't trigger fetch:apiError if request is aborted

### DIFF
--- a/assets/js/src/models/media-collection.js
+++ b/assets/js/src/models/media-collection.js
@@ -264,14 +264,14 @@ var MediaCollection = Backbone.Collection.extend({
 		return fallback.sync.apply(this, arguments);
 	},
 
-	fetchFail: function () {
+	fetchFail: function (response, textStatus) {
 		if (this.pageNumber > 1) {
 			this.pageNumber--;
 		}
 		wpbc.broadcast.trigger('fetch:finished');
 		wpbc.broadcast.trigger('spinner:off');
-		wpbc.broadcast.trigger('fetch:apiError');
-		if (status === 'abort') {
+		if (textStatus !== 'abort') {
+			wpbc.broadcast.trigger('fetch:apiError');
 		}
 	},
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes an issue where the plugin displays the error message when the new filter is applied before the previous ajax is completed. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #355

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Go to the video page.
2. Apply the filters in such a way that you apply the second filter before the ajax request for the first filter is completed.
3. Unselect all the filters.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Display error message when the previous request is aborted
 


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
