### PR TITLE
Fix: Only variables should be passed by reference

### DIFF
--- a/includes/admin/class-bc-admin-labels-page.php
+++ b/includes/admin/class-bc-admin-labels-page.php
@@ -35,7 +35,7 @@ class BC_Admin_Labels_Page {
 	 * Renders html of the edit labels page
 	 */
 	public function render_edit_label_page() {
-		$label_name = $_GET['update_label'] ?? '';
+		$label_name = isset( $_GET['update_label'] ) ? $_GET['update_label'] : '';
 		?>
 		<div class="wrap">
 			<h2>

--- a/includes/admin/class-bc-admin-labels-page.php
+++ b/includes/admin/class-bc-admin-labels-page.php
@@ -35,6 +35,7 @@ class BC_Admin_Labels_Page {
 	 * Renders html of the edit labels page
 	 */
 	public function render_edit_label_page() {
+		$label_name = $_GET['update_label'] ?? '';
 		?>
 		<div class="wrap">
 			<h2>
@@ -46,13 +47,13 @@ class BC_Admin_Labels_Page {
 			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="validate">
 				<?php wp_nonce_field( 'brightcove-edit-label', 'brightcove-edit-label-nonce' ); ?>
 				<input type="hidden" name="action" value="brightcove-edit-label">
-				<input type="hidden" name="label-path" value="<?php echo ! empty( $_GET['update_label'] ) ? esc_attr( $_GET['update_label'] ) : ''; // phpcs:ignore ?>">
+				<input type="hidden" name="label-path" value="<?php esc_attr_e( $label_name, 'brightcove' ); ?>">
 				<table class="form-table">
 					<tbody>
 						<tr class="form-field form-required term-name-wrap">
-							<th scope="row"><label for="name">Label</label></th>
+							<th scope="row"><label for="name"><?php esc_html_e( 'Label', 'brightcove' ); ?></label></th>
 							<td>
-								<input name="label-update" id="name" type="text" value="<?php echo esc_attr( basename( trim( $_GET['update_label'], '/' ) ) ); ?>" size="40" aria-required="true"> <?php // phpcs:ignore WordPress.Security.NonceVerification ?>
+								<input name="label-update" id="name" type="text" value="<?php echo esc_attr( basename( trim( $label_name, '/' ) ) ); ?>" size="40" aria-required="true"> <?php // phpcs:ignore WordPress.Security.NonceVerification ?>
 								<p class="description"><?php esc_html_e( 'Enter the new label name.', 'brightcove' ); ?></p>
 							</td>
 						</tr>

--- a/includes/admin/class-bc-admin-labels-page.php
+++ b/includes/admin/class-bc-admin-labels-page.php
@@ -53,7 +53,7 @@ class BC_Admin_Labels_Page {
 						<tr class="form-field form-required term-name-wrap">
 							<th scope="row"><label for="name"><?php esc_html_e( 'Label', 'brightcove' ); ?></label></th>
 							<td>
-								<input name="label-update" id="name" type="text" value="<?php echo esc_attr( basename( trim( $label_name, '/' ) ) ); ?>" size="40" aria-required="true"> <?php // phpcs:ignore WordPress.Security.NonceVerification ?>
+								<input name="label-update" id="name" type="text" value="<?php echo esc_attr( basename( trim( $label_name, '/' ) ) ); ?>" size="40" aria-required="true">
 								<p class="description"><?php esc_html_e( 'Enter the new label name.', 'brightcove' ); ?></p>
 							</td>
 						</tr>

--- a/includes/admin/class-bc-admin-labels-page.php
+++ b/includes/admin/class-bc-admin-labels-page.php
@@ -35,7 +35,7 @@ class BC_Admin_Labels_Page {
 	 * Renders html of the edit labels page
 	 */
 	public function render_edit_label_page() {
-		$label_name = isset( $_GET['update_label'] ) ? $_GET['update_label'] : '';
+		$label_name = isset( $_GET['update_label'] ) ? $_GET['update_label'] : ''; // phpcs:ignore WordPress.Security.NonceVerification
 		?>
 		<div class="wrap">
 			<h2>
@@ -47,7 +47,7 @@ class BC_Admin_Labels_Page {
 			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="validate">
 				<?php wp_nonce_field( 'brightcove-edit-label', 'brightcove-edit-label-nonce' ); ?>
 				<input type="hidden" name="action" value="brightcove-edit-label">
-				<input type="hidden" name="label-path" value="<?php esc_attr_e( $label_name, 'brightcove' ); ?>">
+				<input type="hidden" name="label-path" value="<?php echo esc_attr( $label_name ); ?>">
 				<table class="form-table">
 					<tbody>
 						<tr class="form-field form-required term-name-wrap">

--- a/includes/admin/class-bc-admin-labels-page.php
+++ b/includes/admin/class-bc-admin-labels-page.php
@@ -52,7 +52,7 @@ class BC_Admin_Labels_Page {
 						<tr class="form-field form-required term-name-wrap">
 							<th scope="row"><label for="name">Label</label></th>
 							<td>
-								<input name="label-update" id="name" type="text" value="<?php echo esc_attr( end( array_filter( explode( '/', $_GET['update_label'] ) ) ) ); ?>" size="40" aria-required="true"> <?php // phpcs:ignore WordPress.Security.NonceVerification ?>
+								<input name="label-update" id="name" type="text" value="<?php echo esc_attr( basename( trim( $_GET['update_label'], '/' ) ) ); ?>" size="40" aria-required="true"> <?php // phpcs:ignore WordPress.Security.NonceVerification ?>
 								<p class="description"><?php esc_html_e( 'Enter the new label name.', 'brightcove' ); ?></p>
 							</td>
 						</tr>


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR fixes an issue where the plugin throws a warning in the label field while editing a label
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #357 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Go to the Labels page
2. Click on Edit label
3. It should display the label value

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - PHP warning while editing a label

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @MARQAS , @felipeelia


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
