### PR TITLE
Fix: Undefined array key sub_type

### DIFF
--- a/includes/admin/api/class-bc-admin-media-api.php
+++ b/includes/admin/api/class-bc-admin-media-api.php
@@ -249,8 +249,9 @@ class BC_Admin_Media_API {
 
 		} elseif ( 'videos' === $_POST['type'] ) {
 			$type_msg = 'video';
-			if ( 'variant' === $_POST['sub_type'] ) {
-				$status = $this->videos->update_bc_video( $updated_data, sanitize_text_field( $_POST['sub_type'] ) );
+			$sub_type = $_POST['sub_type'] ?? '';
+			if ( 'variant' === $sub_type ) {
+				$status = $this->videos->update_bc_video( $updated_data, sanitize_text_field( $sub_type ) );
 			} else {
 				$status = $this->videos->update_bc_video( $updated_data );
 

--- a/includes/admin/api/class-bc-admin-media-api.php
+++ b/includes/admin/api/class-bc-admin-media-api.php
@@ -249,9 +249,9 @@ class BC_Admin_Media_API {
 
 		} elseif ( 'videos' === $_POST['type'] ) {
 			$type_msg = 'video';
-			$sub_type = $_POST['sub_type'] ?? '';
+			$sub_type = isset( $_POST['sub_type'] ) ? sanitize_text_field( $_POST['sub_type'] ) : '';
 			if ( 'variant' === $sub_type ) {
-				$status = $this->videos->update_bc_video( $updated_data, sanitize_text_field( $sub_type ) );
+				$status = $this->videos->update_bc_video( $updated_data, $sub_type );
 			} else {
 				$status = $this->videos->update_bc_video( $updated_data );
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR fixes an issue where the plugin throws a warning while saving the video.
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #354 

### How to test the Change

- Go to the videos page
- Edit a video
- Click on Save
- It should save the video without any errors or notices

<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - PHP warning while saving a video


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @MARQAS , @felipeelia


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
