### PR TITLE
Fix: Don't open the detailed view if button is disabled

### DIFF
--- a/assets/js/src/views/media-details.js
+++ b/assets/js/src/views/media-details.js
@@ -30,11 +30,17 @@ var MediaDetailsView = BrightcoveView.extend({
 
 	triggerEditMedia: function (event) {
 		event.preventDefault();
+		if (event.target.getAttribute('disabled') !== null) {
+			return;
+		}
 		wpbc.broadcast.trigger('edit:media', this.model, this.mediaType);
 	},
 
 	triggerPreviewMedia: function (event) {
 		event.preventDefault();
+		if (event.target.getAttribute('disabled') !== null) {
+			return;
+		}
 		var shortcode = $('#shortcode').val();
 		wpbc.broadcast.trigger('preview:media', this.model, shortcode);
 	},

--- a/assets/js/src/views/media-details.js
+++ b/assets/js/src/views/media-details.js
@@ -30,17 +30,11 @@ var MediaDetailsView = BrightcoveView.extend({
 
 	triggerEditMedia: function (event) {
 		event.preventDefault();
-		if (event.target.getAttribute('disabled') !== null) {
-			return;
-		}
 		wpbc.broadcast.trigger('edit:media', this.model, this.mediaType);
 	},
 
 	triggerPreviewMedia: function (event) {
 		event.preventDefault();
-		if (event.target.getAttribute('disabled') !== null) {
-			return;
-		}
 		var shortcode = $('#shortcode').val();
 		wpbc.broadcast.trigger('preview:media', this.model, shortcode);
 	},

--- a/includes/admin/class-bc-templates.php
+++ b/includes/admin/class-bc-templates.php
@@ -685,8 +685,8 @@ class BC_Admin_Templates {
 					<# } #>
 				</div>
 				<div class="media-actions">
-					<a href="#" class="button media-button brightcove edit"><?php esc_html_e( 'Edit', 'brightcove' ); ?></a>
-					<a href="#" class="button media-button brightcove preview"><?php esc_html_e( 'Preview', 'brightcove' ); ?></a>
+					<button class="button media-button brightcove edit"><?php esc_html_e( 'Edit', 'brightcove' ); ?></button>
+					<button class="button media-button brightcove preview"><?php esc_html_e( 'Preview', 'brightcove' ); ?></button>
 				</div>
 			</div>
 		</script>
@@ -724,14 +724,14 @@ class BC_Admin_Templates {
 
 				<div class="media-actions">
 					<# if ('preview' === data.detailsMode) { #>
-					<a href="#" class="button media-button brightcove back"><?php esc_html_e( 'Back', 'brightcove' ); ?></a>
+					<button class="button media-button brightcove back"><?php esc_html_e( 'Back', 'brightcove' ); ?></button>
 					<# } else { #>
 					<# if ( data.images && data.images.thumbnail && data.images.thumbnail.src ) { #>
-					<a href="#" class="button media-button brightcove edit"><?php esc_html_e( 'Edit', 'brightcove' ); ?></a>
-					<a href="#" class="button media-button brightcove preview"><?php esc_html_e( 'Preview', 'brightcove' ); ?></a>
+					<button class="button media-button brightcove edit"><?php esc_html_e( 'Edit', 'brightcove' ); ?></button>
+					<button class="button media-button brightcove preview"><?php esc_html_e( 'Preview', 'brightcove' ); ?></button>
 					<# } else { #>
-					<a href="#" class="button media-button brightcove edit" disabled><?php esc_html_e( 'Edit', 'brightcove' ); ?></a>
-					<a href="#" class="button media-button brightcove preview" disabled><?php esc_html_e( 'Preview', 'brightcove' ); ?></a>
+					<button class="button media-button brightcove edit" disabled><?php esc_html_e( 'Edit', 'brightcove' ); ?></button>
+					<button class="button media-button brightcove preview" disabled><?php esc_html_e( 'Preview', 'brightcove' ); ?></button>
 					<# } #>
 					<# } #>
 				</div>


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
This PR fixes an issue were clicking on the "Edit" and "Preview" buttons for the "inactive" video gives the white screen.


Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #345

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Clicking on a video and then on "Edit" open the video details to be edited. The only way to go back is to scroll down to the bottom and click "Back". Hitting "Back" on the browser or reloading the page has an unexpected behavior.
2. Clicking on "Edit" on an Inactive video goes to a blank page.

https://github.com/10up/brightcove-video-connect/assets/184628/63f2ae23-c047-4016-9dca-ea13f0db0e78


### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Clicking on the "Edit" and "Preview"  buttons for the inactive videos breakes the layout



### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy @felipeelia 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
