### PR TITLE
Fix: Don't show 'Label added' message if label data is empty

### DIFF
--- a/includes/class-bc-labels.php
+++ b/includes/class-bc-labels.php
@@ -137,8 +137,15 @@ class BC_Labels {
 		) {
 			$label_name = sanitize_text_field( $_POST['label-name'] );
 			$label_path = ! empty( $_POST['label-path'] ) ? $_POST['label-path'] : '';
-			$this->cms_api->add_label( $label_name, $label_path );
-			wp_safe_redirect( admin_url( 'admin.php?page=brightcove-labels&add_label=1&refresh_labels=1' ) );
+
+			$redirect_url = admin_url( 'admin.php?page=brightcove-labels&refresh_labels=1' );
+
+			if ( ! empty( $label_name ) || ! empty( $label_path ) ) {
+				$this->cms_api->add_label( $label_name, $label_path );
+				$redirect_url = add_query_arg( 'add_label', '1', $redirect_url );
+			}
+
+			wp_safe_redirect( $redirect_url);
 			exit;
 		}
 	}

--- a/includes/class-bc-labels.php
+++ b/includes/class-bc-labels.php
@@ -145,7 +145,7 @@ class BC_Labels {
 				$redirect_url = add_query_arg( 'add_label', '1', $redirect_url );
 			}
 
-			wp_safe_redirect( $redirect_url);
+			wp_safe_redirect( $redirect_url );
 			exit;
 		}
 	}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes an issue where the  'Label added' message is displayed even when the label fields are empty. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #356 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Go to the "Labels" page
2. Submit the form without filling in the data
3. The plugin will show the "Label added" notice

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Don't show 'Label added' message if label data is empty
 

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
