### PR TITLE
Send API requests only on the required pages

### DIFF
--- a/includes/class-bc-setup.php
+++ b/includes/class-bc-setup.php
@@ -270,7 +270,6 @@ class BC_Setup {
 	 * @return array|false
 	 */
 	public static function preload_params() {
-
 		global $bc_accounts;
 
 		$tags = new BC_Tags();
@@ -283,8 +282,7 @@ class BC_Setup {
 
 		if ( BC_Utility::current_user_can_brightcove() ) {
 
-			$cms_api         = new BC_CMS_API();
-			$admin_media_api = new BC_Admin_Media_API();
+			$cms_api = new BC_CMS_API();
 
 			if ( false !== strpos( $uri, BC_Admin_Menu::get_playlists_page_uri_component() ) ) {
 				$type                = 'playlists';
@@ -298,7 +296,9 @@ class BC_Setup {
 		$params['nonce']   = wp_create_nonce( '_bc_ajax_search_nonce' );
 		$params['tags']    = $tags->get_tags();
 		$params['folders'] = array();
-		if ( BC_Utility::current_user_can_brightcove() ) {
+
+		$current_page = get_current_screen();
+		if ( BC_Utility::current_user_can_brightcove() && ( 'post' === $current_page->id || false !== strpos( $current_page->id, 'brightcove_page' ) ) ) {
 			$params['folders'] = $cms_api->fetch_folders();
 			$params['labels']  = $cms_api->get_account_labels();
 		}
@@ -342,7 +342,6 @@ class BC_Setup {
 		$params['defaultAccountId'] = ! empty( $default_account['account_id'] ) ? $default_account['account_id'] : '';
 
 		return $params;
-
 	}
 
 	/**
@@ -355,19 +354,11 @@ class BC_Setup {
 
 		$suffix = BC_Utility::get_suffix();
 
-		$player_api = new BC_Player_Management_API2();
-		$players    = $player_api->get_all_players();
-
-		$experiences_api = new BC_Experiences_API();
-		$experiences     = $experiences_api->get_experiences();
-
 		$js_variable = array(
 			'path'           => esc_url( BRIGHTCOVE_URL . 'assets/js/src/' ),
 			'preload'        => self::preload_params(),
 			'wp_version'     => $wp_version,
 			'languages'      => BC_Utility::languages(),
-			'players'        => $players,
-			'experiences'    => $experiences,
 			'str_badformat'  => esc_html__( 'This file is not the proper format. Please use .vtt files, for more information visit', 'brightcove' ),
 			'badformat_link' => esc_url( 'https://support.brightcove.com/en/video-cloud/docs/adding-captions-videos#captionsfile' ),
 			'str_addcaption' => esc_html__( 'Add Another Caption', 'brightcove' ),
@@ -377,6 +368,18 @@ class BC_Setup {
 			'str_apifailure' => esc_html__( "Sorry! We weren't able to reach the Brightcove API even after trying a few times. Please try refreshing the page.", 'brightcove' ),
 			'posts_per_page' => absint( apply_filters( 'brightcove_posts_per_page', 100 ) ), // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page
 		);
+
+		$current_page = get_current_screen();
+		if ( 'post' === $current_page->id ) {
+			$player_api = new BC_Player_Management_API2();
+			$players    = $player_api->get_all_players();
+
+			$experiences_api = new BC_Experiences_API();
+			$experiences     = $experiences_api->get_experiences();
+
+			$js_variable['experiences'] = $experiences;
+			$js_variable['players']     = $players;
+		}
 
 		wp_register_script( 'brightcove', '//sadmin.brightcove.com/js/BrightcoveExperiences.js', array(), BRIGHTCOVE_VERSION, false );
 
@@ -470,7 +473,6 @@ class BC_Setup {
 		}
 
 		return $mime_types;
-
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes the issue where the plugin sends unwanted API calls on all the admin pages.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Limit API calls on unwanted admin pages.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
