### PR TITLE
Cache the Api response

### DIFF
--- a/includes/api/class-bc-api.php
+++ b/includes/api/class-bc-api.php
@@ -130,6 +130,8 @@ abstract class BC_API {
 			 * @param {bool} $cache_fail_response Whether to cache the response.
 			 * @param {string} $url The URL of the request.
 			 * @param {array} $args The arguments of the request.
+			 *
+			 * @return bool Whether to cache the response.
 			 */
 			$cache_fail_response = apply_filters( 'brightcove_cache_api_fail_response', $cache_fail_response, $url, $args );
 

--- a/includes/api/class-bc-api.php
+++ b/includes/api/class-bc-api.php
@@ -131,7 +131,7 @@ abstract class BC_API {
 			 * @param {string} $url The URL of the request.
 			 * @param {array} $args The arguments of the request.
 			 *
-			 * @return bool Whether to cache the response.
+			 * @return bool Whether to cache the fail response.
 			 */
 			$cache_fail_response = apply_filters( 'brightcove_cache_api_fail_response', $cache_fail_response, $url, $args );
 

--- a/includes/api/class-bc-api.php
+++ b/includes/api/class-bc-api.php
@@ -123,7 +123,7 @@ abstract class BC_API {
 			$successful_response_codes = array( 200, 201, 202, 204 );
 
 			/**
-			 * Filter whether to cache the api response.
+			 * Filter whether to cache the api fail response.
 			 *
 			 * @since 2.8.5
 			 * @hook brightcove_cache_api_fail_response
@@ -147,10 +147,10 @@ abstract class BC_API {
 	 * Sends the request to the remote server using the appropriate method and
 	 * logs any errors in the event of failures.
 	 *
-	 * @param string  $url                  the endpoint to connect to
-	 * @param string  $method               the http method to use
-	 * @param array   $data                 array of further data to send to the server
-	 * @param boolean $force_new_token      whether or not to force obtaining a new oAuth token
+	 * @param string  $url             the endpoint to connect to
+	 * @param string  $method          the http method to use
+	 * @param array   $data            array of further data to send to the server
+	 * @param boolean $force_new_token whether or not to force obtaining a new oAuth token
 	 * @param boolean $cache_fail_response  whether or not to cache the api fail response
 	 *
 	 * @return mixed the return data from the call of false if a failure occurred

--- a/includes/api/class-bc-api.php
+++ b/includes/api/class-bc-api.php
@@ -56,7 +56,6 @@ abstract class BC_API {
 		global $bc_accounts;
 
 		return $bc_accounts->get_account_id();
-
 	}
 
 	/**
@@ -90,7 +89,6 @@ abstract class BC_API {
 		}
 
 		return end( array_values( $this->errors ) );
-
 	}
 
 	/**
@@ -98,9 +96,10 @@ abstract class BC_API {
 	 *
 	 * @param  string $url the url to call
 	 * @param  array  $args the arguments to pass to the API call
+	 * @param  bool   $cache_fail_response whether or not to cache the api fail response
 	 * @return array|false|mixed|WP_Error
 	 */
-	private function cached_get( $url, $args ) {
+	private function cached_get( $url, $args, $cache_fail_response = false ) {
 
 		global $bc_accounts;
 
@@ -113,7 +112,9 @@ abstract class BC_API {
 		$account_id            = $bc_accounts->get_account_id();
 		$transient_key         = BC_Utility::generate_transient_key( '_brightcove_req_', $account_id . BC_Utility::get_hash_for_object( $url ) );
 		$request               = BC_Utility::get_cache_item( $transient_key );
-		if ( false === $request ) {
+		$force_refresh         = ! empty( $_GET['bc_refresh'] ) && '1' === $_GET['bc_refresh'] && ! empty( $_GET['nonce'] ) && wp_verify_nonce( $_GET['nonce'], 'bc_refresh' );
+
+		if ( false === $request || $force_refresh ) {
 			if ( function_exists( 'vip_safe_wp_remote_get' ) ) {
 				$request = vip_safe_wp_remote_get( $url, '', 3, 3, 20, $args );
 			} else {
@@ -121,7 +122,18 @@ abstract class BC_API {
 			}
 			$successful_response_codes = array( 200, 201, 202, 204 );
 
-			if ( in_array( wp_remote_retrieve_response_code( $request ), $successful_response_codes, true ) ) {
+			/**
+			 * Filter whether to cache the api response.
+			 *
+			 * @since 2.8.5
+			 * @hook brightcove_cache_api_fail_response
+			 * @param {bool} $cache_fail_response Whether to cache the response.
+			 * @param {string} $url The URL of the request.
+			 * @param {array} $args The arguments of the request.
+			 */
+			$cache_fail_response = apply_filters( 'brightcove_cache_api_fail_response', $cache_fail_response, $url, $args );
+
+			if ( in_array( wp_remote_retrieve_response_code( $request ), $successful_response_codes, true ) || $cache_fail_response ) {
 				BC_Utility::set_cache_item( $transient_key, '', $request, $cache_time_in_seconds );
 			}
 		}
@@ -135,14 +147,15 @@ abstract class BC_API {
 	 * Sends the request to the remote server using the appropriate method and
 	 * logs any errors in the event of failures.
 	 *
-	 * @param string  $url             the endpoint to connect to
-	 * @param string  $method          the http method to use
-	 * @param array   $data            array of further data to send to the server
-	 * @param boolean $force_new_token whether or not to force obtaining a new oAuth token
+	 * @param string  $url                  the endpoint to connect to
+	 * @param string  $method               the http method to use
+	 * @param array   $data                 array of further data to send to the server
+	 * @param boolean $force_new_token      whether or not to force obtaining a new oAuth token
+	 * @param boolean $cache_fail_response  whether or not to cache the api fail response
 	 *
 	 * @return mixed the return data from the call of false if a failure occurred
 	 */
-	protected function send_request( $url, $method = 'GET', $data = array(), $force_new_token = false ) {
+	protected function send_request( $url, $method = 'GET', $data = array(), $force_new_token = false, $cache_fail_response = false ) {
 
 		$method = strtoupper( sanitize_text_field( $method ) );
 
@@ -206,7 +219,7 @@ abstract class BC_API {
 		switch ( $method ) {
 
 			case 'GET':
-				$request = $this->cached_get( $url, $args );
+				$request = $this->cached_get( $url, $args, $cache_fail_response );
 
 				break;
 
@@ -225,7 +238,6 @@ abstract class BC_API {
 
 				$request = wp_remote_request( $url, $args );
 				break;
-
 		}
 
 		if ( 401 === wp_remote_retrieve_response_code( $request ) ) {
@@ -266,11 +278,9 @@ abstract class BC_API {
 			if ( isset( $body[0] ) && isset( $body[0]['error_code'] ) ) {
 
 				$message = $body[0]['error_code'];
-
 			} elseif ( isset( $body['message'] ) ) {
 
 				$message = $body['message'];
-
 			}
 
 			$this->errors[] = array(
@@ -285,18 +295,17 @@ abstract class BC_API {
 		if ( 204 === wp_remote_retrieve_response_code( $request ) ) {
 
 			return true;
-
 		}
 
 		if ( is_wp_error( $request ) ) {
-						$this->errors[] = array(
-							'url'   => $url,
-							'error' => $request,
-						);
+			$this->errors[] = array(
+				'url'   => $url,
+				'error' => $request,
+			);
 
-						BC_Logging::log( sprintf( 'BC API ERROR: %s', $request->get_error_message() ) );
+			BC_Logging::log( sprintf( 'BC API ERROR: %s', $request->get_error_message() ) );
 
-						return false;
+			return false;
 		}
 
 		if ( $transient_key && $body && ( ! defined( 'WP_DEBUG' ) || false === WP_DEBUG ) ) {
@@ -305,7 +314,6 @@ abstract class BC_API {
 		}
 
 		return $body;
-
 	}
 
 	/**
@@ -340,6 +348,5 @@ abstract class BC_API {
 		}
 
 		return 'Bearer ' . $token;
-
 	}
 }

--- a/includes/api/class-bc-player-management-api2.php
+++ b/includes/api/class-bc-player-management-api2.php
@@ -64,7 +64,7 @@ class BC_Player_Management_API2 extends BC_API {
 			$bc_accounts->set_current_account_by_id( $account_id );
 
 			$url             = esc_url_raw( self::BASE_URL . $account_id . '/players/' );
-			$account_players = $this->send_request( $url );
+			$account_players = $this->send_request( $url, 'GET', [], false, true );
 
 			if ( ! $account_players || is_wp_error( $account_players ) ) {
 				return [];

--- a/includes/class-bc-setup.php
+++ b/includes/class-bc-setup.php
@@ -495,12 +495,20 @@ class BC_Setup {
 		}
 
 		if ( count( $bc_accounts->get_sanitized_all_accounts() ) > 0 && empty( $players ) && is_array( $players ) ) {
+			$force_refresh_url = add_query_arg(
+				[
+					'bc_refresh' => 1,
+					'nonce'      => wp_create_nonce( 'bc_refresh' ),
+				],
+				admin_url( 'admin.php?page=brightcove-sources' )
+			);
+
 			$notices[] = array(
 				'message' => sprintf(
-					'%s <a href="%s"><strong>%s</strong></a>',
-					esc_html__( 'It looks like one or more of your accounts API authentication changed recently. Please update your settings ', 'brightcove' ),
+					// translators: %1$s: URL 1, %2$s: URL 2
+					esc_html__( 'It looks like one or more of your accounts API authentication has changed recently. Please update your settings <a href="%1$s"><strong>here</strong></a>. Or click <a href="%2$s"><strong>here</strong></a> to try again.', 'brightcove' ),
 					esc_url( admin_url( 'admin.php?page=brightcove-sources' ) ),
-					esc_html__( 'here', 'brightcove' )
+					esc_url( $force_refresh_url )
 				),
 				'type'    => 'error',
 			);

--- a/includes/class-bc-setup.php
+++ b/includes/class-bc-setup.php
@@ -505,7 +505,7 @@ class BC_Setup {
 
 			$notices[] = array(
 				'message' => sprintf(
-					// translators: %1$s: URL 1, %2$s: URL 2
+					// translators: %1$s: Update settings URL, %2$s: Force refresh URL.
 					esc_html__( 'It looks like one or more of your accounts API authentication has changed recently. Please update your settings <a href="%1$s"><strong>here</strong></a>. Or click <a href="%2$s"><strong>here</strong></a> to try again.', 'brightcove' ),
 					esc_url( admin_url( 'admin.php?page=brightcove-sources' ) ),
 					esc_url( $force_refresh_url )

--- a/includes/class-bc-utility.php
+++ b/includes/class-bc-utility.php
@@ -745,13 +745,7 @@ class BC_Utility {
 		$type       = sanitize_text_field( $type );
 		$expiration = absint( $expiration );
 
-		$transient_value = get_transient( $key );
-
-		if ( false === $transient_value ) {
-			return set_transient( $key, $value, $expiration );
-		}
-
-		return true; // already cached
+		return set_transient( $key, $value, $expiration );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR cache the API response even when the API returns the error 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #367

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Cache the API response and display a message from where use can retry the API again. 
 

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy @jonnynews 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
