### PR TITLE
Fix: Update call fail when labels are empty

### DIFF
--- a/assets/js/src/views/video-edit.js
+++ b/assets/js/src/views/video-edit.js
@@ -385,7 +385,8 @@ var VideoEditView = BrightcoveView.extend({
 		this.model.set('captions', captions);
 
 		// Labels
-		const labels = this.$el.find('.bc-labels-value').val()?.split(',') || [];
+		let labels = this.$el.find('.bc-labels-value').val();
+		labels = labels !== '' ? labels.split(',') : [];
 		this.model.set('labels', labels);
 
 		// Custom fields

--- a/includes/admin/api/class-bc-admin-media-api.php
+++ b/includes/admin/api/class-bc-admin-media-api.php
@@ -173,7 +173,7 @@ class BC_Admin_Media_API {
 
 		$labels = array();
 		if ( isset( $_POST['labels'] ) ) {
-			foreach ( $_POST['labels'] as $label ) {
+			foreach ( array_filter( $_POST['labels'] ) as $label ) {
 				$labels[] = sanitize_text_field( $label );
 			}
 		}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes an issue where the update call fails when the labels are empty. Previously, when labels were empty, the payload had an array an one empty index


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Video update API fails when labels are empty

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
