### PR TITLE
release/2.8.6

### DIFF
--- a/assets/js/src/block.js
+++ b/assets/js/src/block.js
@@ -43,7 +43,7 @@
 			var autoplay = props.attributes.autoplay || '';
 			var playsinline = props.attributes.playsinline || '';
 			var pictureinpicture = props.attributes.picture_in_picture || '';
-			var languageDetection = props.attributes.language_detection || '';
+			var language_detection = props.attributes.language_detection || '';
 			var applicationId = props.attributes.application_id || '';
 			var embed = props.attributes.embed || '';
 			var mute = props.attributes.mute || '';
@@ -204,7 +204,7 @@
 					mute: '',
 					playsinline: '',
 					picture_in_picture: '',
-					languageDetection: '',
+					language_detection: '',
 					embed: attrs.named.embed,
 					sizing: attrs.named.sizing,
 					aspect_ratio: attrs.named.aspect_ratio,
@@ -546,7 +546,7 @@
 						!isExperience &&
 							el(components.CheckboxControl, {
 								label: __('Enable Language Detection', 'brightcove'),
-								checked: languageDetection,
+								checked: language_detection,
 								onChange: function (value) {
 									props.setAttributes({
 										...props.attributes,
@@ -554,7 +554,7 @@
 									});
 								},
 							}),
-						languageDetection === 'languagedetection' ||
+						language_detection === 'languagedetection' ||
 							pictureinpicture === 'pictureinpicture'
 							? el(
 									components.Disabled,

--- a/brightcove-video-connect.php
+++ b/brightcove-video-connect.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Brightcove Video Connect
  * Plugin URI:        https://wordpress.org/plugins/brightcove-video-connect/
  * Description:       A Brightcove™ Connector for WordPress that leverages enhanced APIs and Brightcove™ Capabilities
- * Version:           2.8.5
+ * Version:           2.8.6
  * Requires at least: 4.2
  * Requires PHP:
  * Author:            Brightcove
@@ -39,7 +39,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  021.0.2301  USA
  */
 
-define( 'BRIGHTCOVE_VERSION', '2.8.5' );
+define( 'BRIGHTCOVE_VERSION', '2.8.6' );
 define( 'BRIGHTCOVE_URL', plugin_dir_url( __FILE__ ) );
 define( 'BRIGHTCOVE_PATH', dirname( __FILE__ ) . '/' );
 define( 'BRIGHTCOVE_BASENAME', plugin_basename( __FILE__ ) );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brightcove-video-connect",
-  "version": "2.8.5",
+  "version": "2.8.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "brightcove-video-connect",
-      "version": "2.8.5",
+      "version": "2.8.6",
       "devDependencies": {
         "@10up/cypress-wp-utils": "github:10up/cypress-wp-utils#build",
         "@10up/eslint-config": "^2.3.5",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "title": "brightcove-video-connect",
   "description": "A Brightcove plugin for WordPress.",
-  "version": "2.8.5",
+  "version": "2.8.6",
   "homepage": "https://wordpress.org/plugins/brightcove-video-connect/",
   "author": {
     "name": "Brightcove",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors:      brightcove, 10up, oscarssanchez, collinsinternet, ivankk, tec
 Donate link:       https://supporters.eff.org/donate
 Tags:              brightcove, videos, video
 Tested up to:      6.5
-Stable tag:        2.8.5
+Stable tag:        2.8.6
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -38,6 +38,12 @@ For installation, usage, and Frequently Asked Question please see the [Brightcov
 15. Brightcove Block and Block Settings.
 
 == Changelog ==
+
+= 2.8.6 =
+
+__Fixed:__
+
+* Block recovery would show the first time a video block was added in Gutenberg.
 
 = 2.8.5 - 2023-04-22 =
 


### PR DESCRIPTION
### Description of the Change
Fix the typo in assets/js/src/block.js that causes Block Recovery to be displayed on reload of a new block in a post.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #385

### How to test the Change
Add a brightcove block in a new post and save draft. The block recovery message is not shown on reload.

### Changelog Entry
Fixed - Issue #385 

### Credits
claimableperch

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
