### PR TITLE
Bugfix: combined queries with q parameter

### DIFF
--- a/includes/api/class-bc-cms-api.php
+++ b/includes/api/class-bc-cms-api.php
@@ -439,8 +439,9 @@ class BC_CMS_API extends BC_API {
 			// If Post variables are being escaped, the encoded quote do not return the intended results from the API.
 			$query = stripslashes( $query );
 
-			$args['q'] = sanitize_text_field( $query );
-
+			// Per Brightcove API documentation, the query string should have + to play well with combined queries.
+			// See: https://apis.support.brightcove.com/cms/searching/cms-and-playback-apis-video-search-v2.html
+			$args['q'] = '+' . sanitize_text_field( $query );
 		}
 
 		if ( isset( $args['q'] ) && false === strpos( $args['q'], 'id:' ) ) {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Per Brightcove documentation: https://apis.support.brightcove.com/cms/searching/cms-and-playback-apis-video-search-v2.html, a `+` sign should be added to make the query string parameter mandatory.

This seems to be the only way to make search work with combined queries such as state:active-inactive.

Adding the parameter to the query does not affect single search term negatively.

<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Bug fix: Add + sign to search term parameter for combined queries.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @oscarssanchezz 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
