### PR TITLE
Fix: Single Video Player Embed appears very different in the block editor

### DIFF
--- a/assets/js/src/block.js
+++ b/assets/js/src/block.js
@@ -38,8 +38,6 @@
 			var playlistId = props.attributes.playlist_id || '';
 			var experienceId = props.attributes.experience_id || '';
 			var videoIds = props.attributes.video_ids || '';
-			var minWidth = props.attributes.min_width || '';
-			var paddingTop = props.attributes.padding_top || '';
 			var autoplay = props.attributes.autoplay || '';
 			var playsinline = props.attributes.playsinline || '';
 			var pictureinpicture = props.attributes.picture_in_picture || '';
@@ -50,11 +48,8 @@
 			var sizing = props.attributes.sizing || 'responsive';
 			var aspectRatio = props.attributes.aspect_ratio || '16:9';
 
-			var width = props.attributes.width || '640px';
-			var height = props.attributes.height || '360px';
-
-			const maxHeight = props.attributes.max_height || height;
-			const maxWidth = props.attributes.max_width || width;
+			const width = props.attributes.width || '640px';
+			const height = props.attributes.height || '360px';
 
 			const inPageExperienceId = props.attributes.in_page_experience_id || '';
 
@@ -72,90 +67,22 @@
 			}, [aspectRatio]);
 
 			element.useEffect(() => {
-				if (sizing === 'responsive' && maxWidth && !inPageExperienceId) {
-					props.setAttributes({ ...props.attributes, width: maxWidth || '640px' });
-				}
-			}, [sizing, width, maxWidth, inPageExperienceId]);
-
-			element.useEffect(() => {
-				if (!maxHeight) {
-					let newMaxHeight;
+				if (!experienceId) {
+					let newHeight;
 					if (aspectRatio === '16:9') {
-						newMaxHeight = '360px';
+						newHeight = parseInt(parseInt(width, 10) * (9 / 16), 10) + 'px';
 					} else if (aspectRatio === '4:3') {
-						newMaxHeight = '480px';
+						newHeight = parseInt(parseInt(width, 10) * (3 / 4), 10) + 'px';
 					} else {
-						newMaxHeight = height;
+						newHeight = height;
 					}
 
 					props.setAttributes({
 						...props.attributes,
-						max_height: height === '100%' && newMaxHeight ? newMaxHeight : height,
+						height: newHeight,
 					});
 				}
-			}, []);
-
-			element.useEffect(() => {
-				if (sizing === 'responsive' && height !== '100%' && !inPageExperienceId) {
-					let newMaxHeight;
-					if (aspectRatio === '16:9') {
-						newMaxHeight = '360px';
-					} else if (aspectRatio === '4:3') {
-						newMaxHeight = '480px';
-					} else {
-						newMaxHeight = height;
-					}
-
-					props.setAttributes({
-						...props.attributes,
-						height: '100%',
-						max_height: newMaxHeight,
-					});
-				}
-			}, [height, sizing, aspectRatio, inPageExperienceId]);
-
-			element.useEffect(() => {
-				if (sizing === 'responsive' && !maxHeight && !inPageExperienceId) {
-					let newMaxHeight;
-					if (aspectRatio === '16:9') {
-						newMaxHeight = '360px';
-					} else if (aspectRatio === '4:3') {
-						newMaxHeight = '480px';
-					} else {
-						newMaxHeight = height;
-					}
-
-					props.setAttributes({
-						...props.attributes,
-						max_height: newMaxHeight,
-					});
-				}
-			}, [maxHeight, sizing, aspectRatio, height, inPageExperienceId]);
-
-			element.useEffect(() => {
-				if (
-					sizing === 'fixed' &&
-					(width === '100%' || height === '100%') &&
-					!inPageExperienceId
-				) {
-					props.setAttributes({
-						...props.attributes,
-						width: width === '100%' ? maxWidth : undefined,
-						height: height === '100%' ? maxHeight : undefined,
-					});
-				}
-			}, [width, sizing, height, maxWidth, maxHeight, inPageExperienceId]);
-
-			element.useEffect(() => {
-				if (aspectRatio === 'custom') {
-					const padding_top =
-						typeof maxHeight === 'number' && typeof maxWidth === 'number'
-							? `${(maxHeight / maxWidth) * 100}%`
-							: '56%';
-
-					props.setAttributes({ ...props.attributes, padding_top });
-				}
-			}, [maxWidth, maxHeight, aspectRatio]);
+			}, [width, sizing, aspectRatio, height, experienceId]);
 
 			element.useEffect(() => {
 				if (embed === 'in-page-horizontal' || embed === 'in-page-vertical') {
@@ -370,14 +297,6 @@
 					playlistId;
 			}
 
-			if (typeof height === 'undefined') {
-				height = maxHeight || 250;
-			}
-
-			if (typeof width === 'undefined') {
-				width = maxWidth || 500;
-			}
-
 			const players = wpbc.players[accountId]
 				.filter((player) => {
 					return playlistId ? player.is_playlist : !player.is_playlist;
@@ -483,7 +402,12 @@
 				userPermission ? controls : '',
 				el('iframe', {
 					src: src,
-					style: { height: height, width: width, display: 'block', margin: '0 auto' },
+					style: {
+						height: height,
+						width: width,
+						display: 'block',
+						margin: '0 auto',
+					},
 					allowFullScreen: true,
 					key: 'iframe',
 				}),
@@ -599,40 +523,9 @@
 									},
 								],
 								onChange: function (value) {
-									let height;
-									let padding_top;
-
-									if (value === '16:9') {
-										height = '360px';
-										padding_top = '56%';
-									} else if (value === '4:3') {
-										height = '480px';
-										padding_top = '75%';
-									} else {
-										const maxHeightNumber =
-											maxHeight && Number(maxHeight?.replace(/[^0-9]/g, ''));
-										const maxWidthNumber =
-											maxWidth && Number(maxWidth?.replace(/[^0-9]/g, ''));
-										const isMaxHeightNumber =
-											typeof maxHeightNumber === 'number';
-										const isMaxWidthNumber = typeof maxWidthNumber === 'number';
-
-										height = isMaxHeightNumber ? maxHeight : undefined;
-
-										padding_top =
-											isMaxHeightNumber &&
-											isMaxWidthNumber &&
-											maxHeightNumber > 0
-												? `${(maxHeightNumber / maxWidthNumber) * 100}%`
-												: '56%';
-									}
-
 									props.setAttributes({
 										...props.attributes,
 										aspect_ratio: value,
-										height,
-										max_height: height,
-										padding_top,
 									});
 								},
 							}),
@@ -642,17 +535,10 @@
 								type: 'number',
 								value: width?.replace(/[^0-9]/g, ''),
 								onChange: function (value) {
-									let width = `${value}px`;
-									const max_width = width;
-
-									if (sizing === 'responsive') {
-										width = '100%';
-									}
-
+									const newWidth = `${value}px`;
 									props.setAttributes({
 										...props.attributes,
-										width,
-										max_width,
+										width: newWidth,
 									});
 								},
 							}),
@@ -660,23 +546,13 @@
 							el(components.TextControl, {
 								label: __('Height', 'brightcove'),
 								type: 'number',
-								value:
-									sizing === 'fixed'
-										? height?.replace(/[^0-9]/g, '')
-										: maxHeight?.replace(/[^0-9]/g, ''),
+								value: height?.replace(/[^0-9]/g, ''),
 								disabled: isHeightFieldDisabled,
 								onChange: function (value) {
 									let height = `${value}px`;
-									const max_height = height;
-
-									if (sizing === 'responsive') {
-										height = '100%';
-									}
-
 									props.setAttributes({
 										...props.attributes,
 										height,
-										max_height,
 									});
 								},
 							}),

--- a/assets/js/src/views/media-details.js
+++ b/assets/js/src/views/media-details.js
@@ -183,7 +183,6 @@ var MediaDetailsView = BrightcoveView.extend({
 			paddingTop +
 			'%" autoplay="' +
 			autoplay +
-			'" ' +
 			'" playsinline="' +
 			playsinline +
 			'" picture_in_picture="' +
@@ -192,6 +191,7 @@ var MediaDetailsView = BrightcoveView.extend({
 			languagedetection +
 			'" application_id="' +
 			applicationId +
+			'" ' +
 			'mute="' +
 			mute +
 			'" width="' +
@@ -236,7 +236,7 @@ var MediaDetailsView = BrightcoveView.extend({
 			'" ' +
 			'embed="' +
 			embedStyle +
-			'width="' +
+			'" width="' +
 			width +
 			units +
 			'" height="' +

--- a/assets/js/src/views/media-details.js
+++ b/assets/js/src/views/media-details.js
@@ -167,29 +167,7 @@ var MediaDetailsView = BrightcoveView.extend({
 			width = $('#width').val(),
 			height = $('#height').val(),
 			units = 'px',
-			minWidth = '0px',
-			maxWidth = width + units,
 			shortcode;
-
-		if (aspectRatio === '16:9') {
-			paddingTop = '56';
-		} else if (aspectRatio === '4:3') {
-			paddingTop = '75';
-		} else {
-			paddingTop = (height / width) * 100;
-		}
-
-		if (sizing === 'responsive') {
-			width = '100%';
-			height = '100%';
-		} else {
-			width += units;
-			height += units;
-
-			if (embedStyle === 'iframe') {
-				minWidth = width;
-			}
-		}
 
 		shortcode =
 			'[bc_video video_id="' +
@@ -206,8 +184,6 @@ var MediaDetailsView = BrightcoveView.extend({
 			'%" autoplay="' +
 			autoplay +
 			'" ' +
-			'min_width="' +
-			minWidth +
 			'" playsinline="' +
 			playsinline +
 			'" picture_in_picture="' +
@@ -216,15 +192,14 @@ var MediaDetailsView = BrightcoveView.extend({
 			languagedetection +
 			'" application_id="' +
 			applicationId +
-			'" max_width="' +
-			maxWidth +
-			'" ' +
 			'mute="' +
 			mute +
 			'" width="' +
 			width +
+			units +
 			'" height="' +
 			height +
+			units +
 			'" aspect_ratio="' +
 			aspectRatio +
 			'" sizing="' +
@@ -248,25 +223,10 @@ var MediaDetailsView = BrightcoveView.extend({
 
 		var experienceId = $('#video-player').val(),
 			embedStyle = $('input[name="embed-style"]:checked').val(),
-			sizing = $('input[name="sizing"]:checked').val(),
 			width = $('#width').val(),
 			height = $('#height').val(),
 			units = 'px',
-			minWidth = '0px',
-			maxWidth = width + units,
 			shortcode;
-
-		if (sizing === 'responsive') {
-			width = '100%';
-			height = '100%';
-		} else {
-			width += units;
-			height += units;
-
-			if (embedStyle === 'iframe') {
-				minWidth = width;
-			}
-		}
 
 		shortcode =
 			'[bc_experience experience_id="' +
@@ -276,15 +236,12 @@ var MediaDetailsView = BrightcoveView.extend({
 			'" ' +
 			'embed="' +
 			embedStyle +
-			'" min_width="' +
-			minWidth +
-			'" max_width="' +
-			maxWidth +
-			'" ' +
 			'width="' +
 			width +
+			units +
 			'" height="' +
 			height +
+			units +
 			'" ' +
 			'video_ids="' +
 			videoIds +

--- a/includes/class-bc-in-page-experience-shortcode.php
+++ b/includes/class-bc-in-page-experience-shortcode.php
@@ -66,11 +66,11 @@ class BC_In_Page_Experience_Shortcode {
 				<div data-experience="<?php echo esc_attr( $atts['in_page_experience_id'] ); ?>"></div>
 				<script src="<?php echo esc_url( $published_url ); // phpcs:ignore ?>"></script>
 			<?php else : ?>
-				<iframe 
-				src="<?php echo esc_url( $published_url ); ?>" 
-				allow="autoplay; fullscreen; geolocation; encrypted-media" 
-				allowfullscreen 
-				webkitallowfullscreen 
+				<iframe
+				src="<?php echo esc_url( $published_url ); ?>"
+				allow="autoplay; fullscreen; geolocation; encrypted-media"
+				allowfullscreen
+				webkitallowfullscreen
 				mozallowfullscreen
 				style="<?php echo esc_attr( $style ); ?>">
 				</iframe>
@@ -80,6 +80,6 @@ class BC_In_Page_Experience_Shortcode {
 
 		$html = ob_get_clean();
 
-		return apply_filters( 'brightcove_in_page_experience_html', $html, $atts['experience_id'] );
+		return apply_filters( 'brightcove_in_page_experience_html', $html, $atts['in_page_experience_id'] );
 	}
 }

--- a/includes/class-bc-utility.php
+++ b/includes/class-bc-utility.php
@@ -122,7 +122,6 @@ class BC_Utility {
 
 		// Return true as we may not have expired any videos.
 		return true;
-
 	}
 
 	/**
@@ -234,7 +233,6 @@ class BC_Utility {
 		$existing_hash = get_option( $key );
 
 		return $existing_hash !== $data_hash;
-
 	}
 
 	/**
@@ -685,7 +683,6 @@ class BC_Utility {
 		}
 
 		return $transient_keys;
-
 	}
 
 	/**
@@ -778,7 +775,6 @@ class BC_Utility {
 		} else {
 			return delete_transient( sanitize_key( $key ) );
 		}
-
 	}
 
 	/**
@@ -804,7 +800,6 @@ class BC_Utility {
 		$transient = get_transient( $key );
 
 		return $transient;
-
 	}
 
 	/**
@@ -933,8 +928,6 @@ class BC_Utility {
 		$width          = sanitize_text_field( $atts['width'] );
 		$sizing         = sanitize_text_field( $atts['sizing'] );
 		$min_width      = sanitize_text_field( $atts['min_width'] );
-		$max_width      = sanitize_text_field( $atts['max_width'] );
-		$padding_top    = sanitize_text_field( $atts['padding_top'] );
 		$autoplay       = ( 'autoplay' === $atts['autoplay'] ) ? 'autoplay' : '';
 		$mute           = ( 'muted' === $atts['mute'] ) ? 'muted' : '';
 		$embed          = sanitize_text_field( $atts['embed'] );
@@ -960,7 +953,7 @@ class BC_Utility {
 							controls <?php echo esc_attr( $playsinline ); ?> <?php echo esc_attr( $autoplay ); ?> <?php echo esc_attr( $mute ); ?>
 							data-video-id="<?php echo esc_attr( $id ); ?>"
 							data-application-id="<?php echo esc_attr( $application_id ); ?>"
-							width="<?php echo esc_attr( $width ); ?>" height="315">
+							width="<?php echo esc_attr( $width ); ?>" height="<?php echo esc_attr( $height ); ?>">
 					</video-js>
 					<script src="<?php echo esc_url( $js_src ); ?>"></script> <?php // phpcs:ignore ?>
 				</div>
@@ -975,20 +968,22 @@ class BC_Utility {
 				<?php
 			else :
 				?>
-				<div style="display: block; position: relative; min-width: <?php echo esc_attr( $min_width ); ?>; max-width: <?php echo esc_attr( $max_width ); ?>;">
-					<div style="padding-top: <?php echo esc_attr( $padding_top ); ?>; ">
-						<video-js
-								id="<?php echo esc_attr( $id ); ?>"
-								data-video-id="<?php echo esc_attr( $id ); ?>" data-account="<?php echo esc_attr( $account_id ); ?>"
-								data-player="<?php echo esc_attr( $player_id ); ?>"
-								data-usage="<?php echo esc_attr( self::get_usage_data() ); ?>javascript"
-								data-embed="default" class="video-js"
-								data-application-id="<?php echo esc_attr( $application_id ); ?>"
-								controls <?php echo esc_attr( $playsinline ); ?> <?php echo esc_attr( $autoplay ); ?> <?php echo esc_attr( $mute ); ?>
-								style="width: <?php echo 'responsive' !== $sizing ? esc_attr( $width ) : '100%'; ?>; height: <?php echo esc_attr( $height ); ?>; position: absolute; top: 0; bottom: 0; right: 0; left: 0;">
-						</video-js>
+				<div style="display: block; position: relative; min-width: <?php echo esc_attr( $min_width ); ?>; max-width: <?php echo esc_attr( $width ); ?>;">
+					<video-js
+							id="<?php echo esc_attr( $id ); ?>"
+							data-video-id="<?php echo esc_attr( $id ); ?>" data-account="<?php echo esc_attr( $account_id ); ?>"
+							data-player="<?php echo esc_attr( $player_id ); ?>"
+							data-usage="<?php echo esc_attr( self::get_usage_data() ); ?>javascript"
+							data-embed="default" class="video-js"
+							data-application-id="<?php echo esc_attr( $application_id ); ?>"
+							controls <?php echo esc_attr( $playsinline ); ?> <?php echo esc_attr( $autoplay ); ?> <?php echo esc_attr( $mute ); ?>
+							style="width: <?php echo 'responsive' !== $sizing ? esc_attr( $width ) : '100%'; ?>; height: <?php echo esc_attr( $height ); ?>; position: absolute; top: 0; bottom: 0; right: 0; left: 0;">
+					</video-js>
 
 						<script src="<?php echo esc_url( $js_src ); ?>"></script> <?php // phpcs:ignore ?>
+						<script src="<?php echo esc_url( $js_src ); ?>"></script> <?php // phpcs:ignore ?>
+					</div>
+					<script src="<?php echo esc_url( $js_src ); ?>"></script> <?php // phpcs:ignore ?>
 					</div>
 				</div>
 				<?php
@@ -1035,16 +1030,14 @@ class BC_Utility {
 			);
 			?>
 
-			<div style="display: block; position: relative; min-width: <?php echo esc_attr( $min_width ); ?>; max-width: <?php echo esc_attr( $max_width ); ?>;">
-				<div style="padding-top: <?php echo esc_attr( $padding_top ); ?>; ">
-					<iframe
-							src="<?php echo esc_url( $iframe_src ); ?>"
-							allowfullscreen
-							webkitallowfullscreen
-							mozallowfullscreen
-							style="width: <?php echo 'responsive' !== $sizing ? esc_attr( $width ) : '100%'; ?>; height: <?php echo esc_attr( $height ); ?>; position: absolute; top: 0; bottom: 0; right: 0; left: 0;">
-					</iframe>
-				</div>
+			<div style="display: block; position: relative; min-width: <?php echo esc_attr( $min_width ); ?>; max-width: <?php echo esc_attr( $width ); ?>;">
+				<iframe
+					src="<?php echo esc_url( $iframe_src ); ?>"
+					allowfullscreen
+					webkitallowfullscreen
+					mozallowfullscreen
+					style="width: <?php echo 'responsive' !== $sizing ? esc_attr( $width ) : '100%'; ?>; height: <?php echo esc_attr( $height ); ?>; position: absolute; top: 0; bottom: 0; right: 0; left: 0;">
+				</iframe>
 			</div>
 		<?php endif; ?>
 		<!-- End of Brightcove Player -->
@@ -1085,7 +1078,6 @@ class BC_Utility {
 		$sizing      = sanitize_text_field( $atts['sizing'] );
 		$min_width   = sanitize_text_field( $atts['min_width'] );
 		$max_width   = sanitize_text_field( $atts['max_width'] );
-		$padding_top = sanitize_text_field( $atts['padding_top'] );
 		$autoplay    = ( 'autoplay' === $atts['autoplay'] ) ? 'autoplay' : '';
 		$mute        = ( 'muted' === $atts['mute'] ) ? 'muted' : '';
 		$embed       = sanitize_text_field( $atts['embed'] );
@@ -1240,15 +1232,13 @@ class BC_Utility {
 			?>
 
 			<div style="display: block; position: relative; min-width: <?php echo esc_attr( $min_width ); ?>; max-width: <?php echo esc_attr( $max_width ); ?>;">
-				<div style="padding-top: <?php echo esc_attr( $padding_top ); ?>; ">
-					<iframe
-							src="<?php echo esc_url( $iframesrc ); ?>"
-							allowfullscreen
-							webkitallowfullscreen
-							mozallowfullscreen
-							style="width: <?php echo 'responsive' !== $sizing ? esc_attr( $width ) : '100%'; ?>; height: <?php echo esc_attr( $height ); ?>; position: absolute; top: 0; bottom: 0; right: 0; left: 0;">
-					</iframe>
-				</div>
+				<iframe
+					src="<?php echo esc_url( $iframesrc ); ?>"
+					allowfullscreen
+					webkitallowfullscreen
+					mozallowfullscreen
+					style="width: <?php echo 'responsive' !== $sizing ? esc_attr( $width ) : '100%'; ?>; height: <?php echo esc_attr( $height ); ?>; position: absolute; top: 0; bottom: 0; right: 0; left: 0;">
+				</iframe>
 			</div>
 		<?php else : ?>
 


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
This PR fixes the issue where the video width and height is different as compare to frontend.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Video appearance in the editor



### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
