### PR TITLE
Allow only png and jpg images for thumbnail and poster

### DIFF
--- a/assets/js/src/views/video-edit.js
+++ b/assets/js/src/views/video-edit.js
@@ -73,18 +73,19 @@ var VideoEditView = BrightcoveView.extend({
 	openMediaManager: function (evnt) {
 		evnt.preventDefault();
 
-		var elem = $(evnt.currentTarget).parents('.setting'),
-			editor = elem.data('editor'),
-			mediaManager = (wp.media.frames.brightcove = wp.media()),
-			that = this,
-			options = {
-				state: 'insert',
-				title: wp.media.view.l10n.addMedia,
-				multiple: false,
-			};
+		const options = {
+			title: wp.media.view.l10n.addMedia,
+			multiple: false,
+			library: {
+				type: ['image/jpeg', 'image/png'],
+			},
+		};
+
+		const mediaManager = wp.media(options);
+		const that = this;
 
 		// Open the media manager
-		mediaManager.open(editor, options);
+		mediaManager.open();
 
 		// Listen for selection of media
 		mediaManager.on('select', function () {
@@ -587,15 +588,6 @@ var VideoEditView = BrightcoveView.extend({
 		this.listenTo(wpbc.broadcast, 'spinner:off', function () {
 			spinner.removeClass('is-active').addClass('hidden');
 		});
-
-		// If there's already a poster or thumbnail set, display it
-		if (this.model.get('poster')) {
-			this.displayAttachment('poster');
-		}
-
-		if (this.model.get('thumbnail')) {
-			this.displayAttachment('thumbnail');
-		}
 
 		// Captions
 		if (this.model.get('captions')) {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Only show jpg and png images in the media modal

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @burhandodhy 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
